### PR TITLE
build(frontend): update react-router-dom to v6

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,7 +36,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-map-gl": "^5.3.21",
-        "react-router-dom": "^5.3.4",
+        "react-router-dom": "^6.23.1",
         "react-scripts": "^5.0.0",
         "react-spring-bottom-sheet": "^3.4.1",
         "react-transition-group": "^4.4.2",
@@ -4453,6 +4453,14 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@recoiljs/refine/-/refine-0.1.1.tgz",
       "integrity": "sha512-ry02rHswJePYkH1o8K99qL4O6TBntF9/g7W5wXVwaOUrIJEZUGfl/I3+btPXbUgyyEZvNs5xcwvOw13AufmFQw=="
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
+      "integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -10956,19 +10964,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -14721,19 +14716,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/path-to-regexp/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -16634,45 +16616,34 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
+      "integrity": "sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.16.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.1.tgz",
+      "integrity": "sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.16.1",
+        "react-router": "6.23.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
-    },
-    "node_modules/react-router/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-scripts": {
       "version": "5.0.1",
@@ -17251,11 +17222,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "node_modules/resolve-protobuf-schema": {
       "version": "2.1.0",
@@ -19259,16 +19225,6 @@
       "resolved": "https://registry.npmjs.org/tileserver-gl-styles/-/tileserver-gl-styles-2.0.0.tgz",
       "integrity": "sha512-LJ0zjDsRFwEIM9hHnZ8SLnAVUPMlJUJuC+vluvfnYD6JIKtGYv6LizdIyBcB9DYqvyd8nzPSpVHJIHGd/HJVlQ=="
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "node_modules/tinyqueue": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
@@ -19946,11 +19902,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/varint": {
       "version": "4.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-map-gl": "^5.3.21",
-    "react-router-dom": "^5.3.4",
+    "react-router-dom": "^6.23.1",
     "react-scripts": "^5.0.0",
     "react-spring-bottom-sheet": "^3.4.1",
     "react-transition-group": "^4.4.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { RecoilRoot } from 'recoil';
-import { Route, BrowserRouter as Router, Switch } from 'react-router-dom';
+import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 import { Box, CssBaseline, StyledEngineProvider } from '@mui/material';
 import { ThemeProvider } from '@mui/material/styles';
 
@@ -67,21 +67,12 @@ export const App = () => {
                 left={0}
                 right={0}
               >
-                <Switch>
-                  <Route path="/" exact>
-                    <IntroPage />
-                  </Route>
-                  <Route
-                    path="/:view(exposure|risk|adaptation|nature-based-solutions)"
-                    render={({ match: { params } }) => <MapPage view={params.view} />}
-                  />
-                  <Route path="/data" exact>
-                    <DataPage />
-                  </Route>
-                  <Route path="/guide" exact>
-                    <GuidePage />
-                  </Route>
-                </Switch>
+                <Routes>
+                  <Route path="/" element={<IntroPage />} />
+                  <Route path="/:view" element={<MapPage />} />
+                  <Route path="/data" element={<DataPage />} />
+                  <Route path="/guide" element={<GuidePage />} />
+                </Routes>
               </Box>
             </Router>
           </ThemeProvider>

--- a/frontend/src/lib/nav.tsx
+++ b/frontend/src/lib/nav.tsx
@@ -1,10 +1,10 @@
 import { LinkProps, Link as MuiLink } from '@mui/material';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
 
 export const ExtLink = ({ ...props }: Omit<LinkProps<'a'>, 'component'>) => {
   return <MuiLink target="_blank" rel="noopener noreferrer" {...props} />;
 };
 
-export const AppLink = ({ ...props }: Omit<LinkProps<RouterLink>, 'component'>) => {
+export const AppLink = ({ ...props }: Omit<RouterLinkProps, 'component'>) => {
   return <MuiLink component={RouterLink} {...props} />;
 };

--- a/frontend/src/pages/map/MapPage.tsx
+++ b/frontend/src/pages/map/MapPage.tsx
@@ -9,12 +9,12 @@ import { viewState, viewStateEffect } from 'state/view';
 import { MapPageDesktopLayout } from './layouts/MapPageDesktopLayout';
 import { useIsMobile } from 'use-is-mobile';
 import { MapPageMobileLayout } from './layouts/mobile/MapPageMobileLayout';
+import { useParams } from 'react-router-dom';
 
-interface MapPageProps {
-  view: string;
-}
+interface MapPageProps {}
 
-export const MapPage: FC<MapPageProps> = ({ view }) => {
+export const MapPage: FC<MapPageProps> = () => {
+  const { view } = useParams();
   useSyncRecoilState(viewState, view);
 
   const isMobile = useIsMobile();


### PR DESCRIPTION
- switch from `Switch` to `Routes`
- new, simplified `Route` API.
- `useParams` to get map view.
- updated types.