### PR TITLE
build(frontend): upgrade dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,8 +28,8 @@
         "d3-scale": "^4.0.2",
         "d3-scale-chromatic": "^3.0.0",
         "deck.gl": "8.9",
-        "http-proxy-middleware": "^2.0.1",
-        "immer": "^9.0.21",
+        "http-proxy-middleware": "^3.0.0",
+        "immer": "^10.1.1",
         "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.21",
         "mapbox-gl": "^1.13.1",
@@ -67,7 +67,7 @@
         "@types/react-router-dom": "^5.1.8",
         "@types/react-transition-group": "^4.4.4",
         "openapi-typescript-codegen": "^0.21.0",
-        "prettier": "^2.3.2",
+        "prettier": "^3.2.5",
         "typescript": "^4.5.5"
       }
     },
@@ -11221,26 +11221,19 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.0.tgz",
+      "integrity": "sha512-36AV1fIaI2cWRzHo+rbcxhe3M3jUDCNzc4D5zRl57sEWRAxdXYtw7FSQKYY6PDKssiAKjLYypbssHk+xs/kMXw==",
       "dependencies": {
-        "@types/http-proxy": "^1.17.8",
+        "@types/http-proxy": "^1.17.10",
+        "debug": "^4.3.4",
         "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
         "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
+        "micromatch": "^4.0.5"
       },
       "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@types/express": "^4.17.13"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        }
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/http-shutdown": {
@@ -11358,9 +11351,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -16092,15 +16085,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -16503,6 +16496,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/react-dev-utils/node_modules/immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/react-dev-utils/node_modules/loader-utils": {
@@ -20742,6 +20744,29 @@
       },
       "peerDependencies": {
         "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
+      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.8",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.13"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        }
       }
     },
     "node_modules/webpack-dev-server/node_modules/ipaddr.js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,8 +23,8 @@
     "d3-scale": "^4.0.2",
     "d3-scale-chromatic": "^3.0.0",
     "deck.gl": "8.9",
-    "http-proxy-middleware": "^2.0.1",
-    "immer": "^9.0.21",
+    "http-proxy-middleware": "^3.0.0",
+    "immer": "^10.1.1",
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.21",
     "mapbox-gl": "^1.13.1",
@@ -62,7 +62,7 @@
     "@types/react-router-dom": "^5.1.8",
     "@types/react-transition-group": "^4.4.4",
     "openapi-typescript-codegen": "^0.21.0",
-    "prettier": "^2.3.2",
+    "prettier": "^3.2.5",
     "typescript": "^4.5.5"
   },
   "scripts": {

--- a/frontend/src/asset-list/FieldSpecControl.tsx
+++ b/frontend/src/asset-list/FieldSpecControl.tsx
@@ -1,5 +1,5 @@
 import { Box, Typography } from '@mui/material';
-import produce from 'immer';
+import { produce } from 'immer';
 import { ParamDropdown } from 'lib/controls/ParamDropdown';
 import { FieldSpec } from 'lib/data-map/view-layers';
 import { FC } from 'react';

--- a/frontend/src/lib/controls/checkbox-tree/CheckboxTree.tsx
+++ b/frontend/src/lib/controls/checkbox-tree/CheckboxTree.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { SimpleTreeView } from '@mui/x-tree-view';
-import produce from 'immer';
+import { produce } from 'immer';
 
 import { dfs, getDescendants, TreeNode } from './tree-node';
 import { CheckboxTreeItem } from './CheckboxTreeItem';

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -6,12 +6,12 @@
  *
  * See guide at https://create-react-app.dev/docs/proxying-api-requests-in-development/#configuring-the-proxy-manually
  */
-const { createProxyMiddleware } = require('http-proxy-middleware');
+const { legacyCreateProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = function (app) {
   app.use(
     '/vector',
-    createProxyMiddleware({
+    legacyCreateProxyMiddleware({
       target: 'http://localhost:8080',
       changeOrigin: true,
       pathRewrite: {
@@ -21,7 +21,7 @@ module.exports = function (app) {
   );
   app.use(
     '/raster',
-    createProxyMiddleware({
+    legacyCreateProxyMiddleware({
       target: 'http://localhost:5000',
       changeOrigin: true,
       pathRewrite: {
@@ -31,7 +31,7 @@ module.exports = function (app) {
   );
   app.use(
     '/api',
-    createProxyMiddleware({
+    legacyCreateProxyMiddleware({
       target: 'http://localhost:8888',
       changeOrigin: true,
       pathRewrite: {


### PR DESCRIPTION
- bump `immer` to v10.
- bump `prettier` to v3.
- bump `http-proxy-middleware` to v3.