### PR TITLE
chore(frontend): clean up ESLint errors

### DIFF
--- a/frontend/src/Nav.tsx
+++ b/frontend/src/Nav.tsx
@@ -7,13 +7,14 @@ import {
   List,
   ListItem,
   Link as MuiLink,
+  LinkProps,
   Toolbar,
   Tooltip,
   styled,
 } from '@mui/material';
 import { Box } from '@mui/system';
 import { FC, forwardRef, useCallback, useState } from 'react';
-import { NavLink as RouterNavLink } from 'react-router-dom';
+import { NavLink as RouterNavLink, LinkProps as RouterLinkProps } from 'react-router-dom';
 
 import { useIsMobile } from '../src/use-is-mobile';
 import { withProps } from 'lib/react/with-props';
@@ -25,6 +26,9 @@ const Link = styled(MuiLink)({
 });
 
 const DrawerLink = styled(Link)({
+  height: '100%',
+  width: '100%',
+  padding: '0.5rem 1rem',
   '&.active': {
     backgroundColor: '#eeeeee',
   },
@@ -42,13 +46,15 @@ const ToolbarLink = styled(Link)({
   },
 });
 
-const ToolbarNavLink = forwardRef<any, any>(({ ...others }, ref) => (
-  <ToolbarLink variant="h6" component={RouterNavLink} ref={ref} {...others} />
-));
+const ToolbarLinkWithRef = (props, ref) => (
+  <ToolbarLink component={RouterNavLink} ref={ref} {...props} />
+);  
+const ToolbarNavLink = forwardRef<HTMLAnchorElement, LinkProps & RouterLinkProps>(ToolbarLinkWithRef);
 
-const DrawerNavLink = forwardRef<any, any>(({ ...others }, ref) => (
-  <DrawerLink component={RouterNavLink} ref={ref} {...others} />
-));
+const DrawerLinkWithRef = (props, ref) => (
+  <DrawerLink component={RouterNavLink} ref={ref} {...props} />
+);
+const DrawerNavLink = forwardRef<HTMLAnchorElement, LinkProps & RouterLinkProps>(DrawerLinkWithRef);
 
 const GrowingDivider = styled(Divider)({
   flexGrow: 1,
@@ -88,14 +94,18 @@ const MobileNavContent: FC<{ navItems: NavItemConfig[] }> = ({ navItems }) => {
       <MobileDrawer open={drawerOpen} onClose={closeDrawer}>
         <Toolbar /> {/* Prevents app bar from concealing content*/}
         <List>
-          <ListItem component={DrawerNavLink} to="/" exact onClick={closeDrawer}>
-            Home
+          <ListItem disablePadding >
+            <DrawerNavLink to="/" onClick={closeDrawer}>
+              Home
+            </DrawerNavLink>
           </ListItem>
           {navItems.map(({ to, title, tooltip }) => (
             <NavTooltip key={to} title={tooltip} placement="right">
-              <ListItem component={DrawerNavLink} to={to} onClick={closeDrawer}>
-                {title}
-              </ListItem>
+              <ListItem disablePadding >
+                <DrawerNavLink to={to} onClick={closeDrawer}>
+                  {title}
+                </DrawerNavLink>
+            </ListItem>
             </NavTooltip>
           ))}
         </List>

--- a/frontend/src/Notice.tsx
+++ b/frontend/src/Notice.tsx
@@ -21,12 +21,9 @@ const noticeAcceptedDateState = atom<Date | null>({
 export const Notice = () => {
   const [acceptedDate, setAcceptedDate] = useRecoilState(noticeAcceptedDateState);
 
-  const handleAccept = useCallback(
-    () => {
-      setAcceptedDate(new Date());
-    },
-    [setAcceptedDate],
-  );
+  const handleAccept = useCallback(() => {
+    setAcceptedDate(new Date());
+  }, [setAcceptedDate]);
 
   return (
     <Drawer variant="persistent" anchor="bottom" open={acceptedDate == null}>

--- a/frontend/src/config/drought/data-formats.ts
+++ b/frontend/src/config/drought/data-formats.ts
@@ -13,7 +13,7 @@ const riskLabelLookup = toDictionary(
   (x) => x.label,
 );
 
-const riskValueFormatLookup: Record<DroughtRiskVariableType, (x: any) => string> = {
+const riskValueFormatLookup: Record<DroughtRiskVariableType, (x: number) => string> = {
   mean_monthly_water_stress_: (x) => numFormat(x),
   epd: (x) => numFormat(x),
   eael: (x) => `$${numFormat(x)}`,
@@ -32,7 +32,7 @@ const optionsLabelLookup = toDictionary(
   (x) => x.label,
 );
 
-const optionsValueFormatLookup: Record<DroughtOptionsVariableType, (x: any) => string> = {
+const optionsValueFormatLookup: Record<DroughtOptionsVariableType, (x: number) => string> = {
   cost_jmd: (x) => `$${numFormat(x)}`,
   population_protected: (x) => numFormat(x, 21),
   net_present_value_benefit: (x) => `$${numFormat(x)}`,

--- a/frontend/src/config/solutions/data-access.ts
+++ b/frontend/src/config/solutions/data-access.ts
@@ -2,6 +2,6 @@ import { FieldSpec } from 'lib/data-map/view-layers';
 import { featureProperty } from 'lib/deck/props/data-source';
 import { Accessor } from 'lib/deck/props/getters';
 
-export function getSolutionsDataAccessor(fieldSpec: FieldSpec): Accessor<any> {
+export function getSolutionsDataAccessor(fieldSpec: FieldSpec): Accessor<string> {
   return fieldSpec && featureProperty(fieldSpec.field);
 }

--- a/frontend/src/details/adaptations/AdaptationsSidebar.tsx
+++ b/frontend/src/details/adaptations/AdaptationsSidebar.tsx
@@ -6,7 +6,7 @@ import { FC } from 'react';
 import { FeatureAdaptationsTable } from './FeatureAdaptationsTable';
 import { MobileTabContentWatcher } from 'pages/map/layouts/mobile/tab-has-content';
 
-export const AdaptationsSidebar: FC<{}> = () => {
+export const AdaptationsSidebar: FC = () => {
   return (
     <SidePanel height="80vh" pb={1} px={0} pt={0}>
       <MobileTabContentWatcher tabId="details" />

--- a/frontend/src/details/features/FeatureSidebar.tsx
+++ b/frontend/src/details/features/FeatureSidebar.tsx
@@ -9,7 +9,7 @@ import { Box } from '@mui/system';
 import { DeselectButton } from 'details/DeselectButton';
 import { MobileTabContentWatcher } from 'pages/map/layouts/mobile/tab-has-content';
 
-export const FeatureSidebar: FC<{}> = () => {
+export const FeatureSidebar: FC = () => {
   const featureSelection = useRecoilValue(selectionState('assets'));
 
   if (!featureSelection) return null;

--- a/frontend/src/details/features/FeatureSidebarContent.tsx
+++ b/frontend/src/details/features/FeatureSidebarContent.tsx
@@ -99,7 +99,7 @@ const componentMapping: Record<keyof typeof NETWORKS_METADATA, DetailsComponent>
 };
 
 interface FeatureSidebarContentProps {
-  feature: any;
+  feature: { id: number; properties: Record<string, string> };
   assetType: string;
   showRiskSection?: boolean;
 }

--- a/frontend/src/details/features/adaptation/AdaptationTable.tsx
+++ b/frontend/src/details/features/adaptation/AdaptationTable.tsx
@@ -29,7 +29,7 @@ export const AdaptationTable = ({ options }) => {
         </TableHead>
         <TableBody>
           {options.map((d) => (
-            <TableRow>
+            <TableRow key={d.hazard}>
               <TableCell sx={{ pl: 0, pr: padding.px, py: padding.py }}>{d.hazard}</TableCell>
               <TableCell sx={padding}>{d.rcp}</TableCell>
               <TableCell sx={padding}>{d.adaptation_protection_level}</TableCell>

--- a/frontend/src/details/features/damages/ExpectedDamageChart.tsx
+++ b/frontend/src/details/features/damages/ExpectedDamageChart.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { VegaLite } from 'react-vega';
+import { PlainObject, VegaLite } from 'react-vega';
 
 import { unique } from 'lib/helpers';
 
@@ -85,5 +85,5 @@ export const ExpectedDamageChart = ({
     [data, field_min, field, field_max, field_title],
   );
 
-  return <VegaLite data={data} spec={spec as any} {...props} />;
+  return <VegaLite data={data} spec={spec as PlainObject} {...props} />;
 };

--- a/frontend/src/details/features/damages/ReturnPeriodDamageChart.tsx
+++ b/frontend/src/details/features/damages/ReturnPeriodDamageChart.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { VegaLite } from 'react-vega';
+import { PlainObject, VegaLite } from 'react-vega';
 
 import { unique } from 'lib/helpers';
 
@@ -73,5 +73,5 @@ export const ReturnPeriodDamageChart = ({ data, field_key, field_title, ...props
     [data, field_key, field_title],
   );
 
-  return <VegaLite data={data} spec={spec as any} {...props} />;
+  return <VegaLite data={data} spec={spec as PlainObject} {...props} />;
 };

--- a/frontend/src/details/solutions/SolutionsSidebar.tsx
+++ b/frontend/src/details/solutions/SolutionsSidebar.tsx
@@ -8,7 +8,7 @@ import { useRecoilValue } from 'recoil';
 import { SolutionsSidebarContent } from './SolutionsSidebarContent';
 import { MobileTabContentWatcher } from 'pages/map/layouts/mobile/tab-has-content';
 
-export const SolutionsSidebar: FC<{}> = () => {
+export const SolutionsSidebar: FC = () => {
   const featureSelection = useRecoilValue(selectionState('solutions'));
 
   if (!featureSelection) return null;

--- a/frontend/src/map/legend/MapLegend.tsx
+++ b/frontend/src/map/legend/MapLegend.tsx
@@ -9,7 +9,7 @@ import { VectorLegend } from './VectorLegend';
 import { Stack, Box, Paper, Divider } from '@mui/material';
 import { MobileTabContentWatcher } from 'pages/map/layouts/mobile/tab-has-content';
 
-export const MapLegend: FC<{}> = () => {
+export const MapLegend: FC = () => {
   const viewLayers = useRecoilValue(viewLayersFlatState);
   const viewLayersParams = useRecoilValue(viewLayersParamsState);
 

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -309,7 +309,7 @@ export const GuidePage = () => (
     <p>
       On the “Adaptation” page, the second sidebar section contains controls to show drought risk
       and drought-related adaptation options. Select for example “Population at risk” to see areas
-      coloured by risk and "Population protected" to see points representing approximate locations
+      coloured by risk and &ldquo;Population protected&rdquo; to see points representing approximate locations
       of options to reduce the impacts of drought.
     </p>
     <p>

--- a/frontend/src/pages/IntroPage.tsx
+++ b/frontend/src/pages/IntroPage.tsx
@@ -90,7 +90,7 @@ export const IntroPage = () => (
               in the Environmental Change Institute, University of Oxford, with the Government of
               Jamaica (GoJ), funded by UK Aid through the UK Foreign and Commonwealth Development
               Office (FCDO). The initiative forms part of the Coalition for Climate Resilient
-              Investment&rsquo;s (CCRI) work on "Systemic Resilience" in collaboration with the
+              Investment&rsquo;s (CCRI) work on &ldquo;Systemic Resilience&rdquo; in collaboration with the
               Green Climate Fund.
             </p>
 

--- a/frontend/src/sidebar/SidebarContent.tsx
+++ b/frontend/src/sidebar/SidebarContent.tsx
@@ -21,7 +21,7 @@ const viewLabels = {
   'nature-based-solutions': 'Nature-based Solutions',
 };
 
-const SidebarContent: FC<{}> = () => {
+const SidebarContent: FC = () => {
   const view = useRecoilValue(viewState);
   switch (view) {
     case 'exposure':

--- a/frontend/src/sidebar/drought/DroughtsControl.tsx
+++ b/frontend/src/sidebar/drought/DroughtsControl.tsx
@@ -17,7 +17,7 @@ import {
   droughtShowRiskState,
 } from 'state/drought/drought-parameters';
 
-export const DroughtsControl: FC<{}> = () => {
+export const DroughtsControl: FC = () => {
   const [rcp, setRcp] = useRecoilState(droughtRcpParamState);
   const [showRisk, setShowRisk] = useRecoilState(droughtShowRiskState);
   const [showOptions, setShowOptions] = useRecoilState(droughtShowOptionsState);

--- a/frontend/src/sidebar/drought/DroughtsSection.tsx
+++ b/frontend/src/sidebar/drought/DroughtsSection.tsx
@@ -4,7 +4,7 @@ import { SidebarPanel } from 'sidebar/SidebarPanel';
 import { SidebarPanelSection } from 'sidebar/ui/SidebarPanelSection';
 import { DroughtsControl } from './DroughtsControl';
 
-export const DroughtsSection: FC<{}> = () => {
+export const DroughtsSection: FC = () => {
   return (
     <SidebarPanel id="drought" title="Drought">
       <ErrorBoundary message="There was a problem displaying this section.">

--- a/frontend/src/sidebar/hazards/HazardsSection.tsx
+++ b/frontend/src/sidebar/hazards/HazardsSection.tsx
@@ -4,7 +4,7 @@ import { SidebarPanel } from 'sidebar/SidebarPanel';
 import { Box } from '@mui/system';
 import { ErrorBoundary } from 'lib/react/ErrorBoundary';
 
-export const HazardsSection: FC<{}> = () => {
+export const HazardsSection: FC = () => {
   return (
     <SidebarPanel id="hazards" title="Hazards">
       <Box p={2}>

--- a/frontend/src/sidebar/networks/AdaptationControl.tsx
+++ b/frontend/src/sidebar/networks/AdaptationControl.tsx
@@ -63,7 +63,7 @@ const CostBenefitRatioInputs: FC = () => {
   );
 };
 
-export const AdaptationControl: FC<{}> = () => {
+export const AdaptationControl: FC = () => {
   const [adaptationField, setAdaptationField] = useRecoilState(adaptationFieldState);
   return (
     <LayerStylePanel>

--- a/frontend/src/sidebar/networks/NetworkControl.tsx
+++ b/frontend/src/sidebar/networks/NetworkControl.tsx
@@ -15,7 +15,7 @@ import { showAdaptationsState } from 'state/layers/networks';
 import { Box } from '@mui/system';
 import { Alert } from '@mui/material';
 
-export const NetworkControl: FC<{}> = () => {
+export const NetworkControl: FC = () => {
   const [checkboxState, setCheckboxState] = useRecoilState(networkTreeCheckboxState);
   const [expanded, setExpanded] = useRecoilState(networkTreeExpandedState);
 

--- a/frontend/src/sidebar/networks/NetworksSection.tsx
+++ b/frontend/src/sidebar/networks/NetworksSection.tsx
@@ -14,7 +14,7 @@ import { networksStyleStateEffect, sectionStyleValueState } from 'state/sections
 import { AdaptationControl } from './AdaptationControl';
 import { ErrorBoundary } from 'lib/react/ErrorBoundary';
 
-export const NetworksSection: FC<{}> = () => {
+export const NetworksSection: FC = () => {
   const style = useRecoilValue(sectionStyleValueState('assets'));
   return (
     <SidebarPanel id="assets" title="Infrastructure">

--- a/frontend/src/sidebar/regions/RegionsSection.tsx
+++ b/frontend/src/sidebar/regions/RegionsSection.tsx
@@ -5,7 +5,7 @@ import { StyleSelection } from 'sidebar/StyleSelection';
 import { SidebarPanelSection } from 'sidebar/ui/SidebarPanelSection';
 import { ErrorBoundary } from 'lib/react/ErrorBoundary';
 
-export const RegionsSection: FC<{}> = () => {
+export const RegionsSection: FC = () => {
   return (
     <SidebarPanel id="regions" title="Regions">
       <ErrorBoundary message="There was a problem displaying this section.">

--- a/frontend/src/sidebar/solutions/MarineSection.tsx
+++ b/frontend/src/sidebar/solutions/MarineSection.tsx
@@ -4,7 +4,7 @@ import { SidebarPanel } from 'sidebar/SidebarPanel';
 import { SidebarPanelSection } from 'sidebar/ui/SidebarPanelSection';
 import { MarineControl } from './MarineControl';
 
-export const MarineSection: FC<{}> = () => {
+export const MarineSection: FC = () => {
   return (
     <SidebarPanel id="marine" title="Marine">
       <ErrorBoundary message="There was a problem displaying this section.">

--- a/frontend/src/sidebar/solutions/TerrestrialSection.tsx
+++ b/frontend/src/sidebar/solutions/TerrestrialSection.tsx
@@ -5,7 +5,7 @@ import { StyleSelection } from 'sidebar/StyleSelection';
 import { SidebarPanelSection } from 'sidebar/ui/SidebarPanelSection';
 import { TerrestrialControl } from './TerrestrialControl';
 
-export const TerrestrialSection: FC<{}> = () => {
+export const TerrestrialSection: FC = () => {
   return (
     <SidebarPanel id="terrestrial" title="Terrestrial">
       <ErrorBoundary message="There was a problem displaying this section.">

--- a/frontend/src/state/is-retina.ts
+++ b/frontend/src/state/is-retina.ts
@@ -1,10 +1,22 @@
 import { atom } from 'recoil';
 
+interface WindowWithDevicePixelRatio extends Window {
+  devicePixelRatio: number;
+  screen: ScreenWithDPR;
+};
+
+interface ScreenWithDPR extends Screen {
+  deviceXDPI: number;
+  logicalXDPI: number;
+}
+
+
 function checkIsRetina() {
   // taken from Leaflet source: https://github.com/Leaflet/Leaflet/blob/ee71642691c2c71605bacff69456760cfbc80a2a/src/core/Browser.js#L119
+  const windowWithDPR = window as unknown as WindowWithDevicePixelRatio;
   return (
-    (window.devicePixelRatio ||
-      (window.screen as any).deviceXDPI / (window.screen as any).logicalXDPI) > 1
+    (windowWithDPR.devicePixelRatio ||
+      windowWithDPR.screen.deviceXDPI / windowWithDPR.screen.logicalXDPI) > 1
   );
 }
 

--- a/frontend/src/state/layers/networks.ts
+++ b/frontend/src/state/layers/networks.ts
@@ -95,7 +95,9 @@ export const adaptationFieldSpecState = selector<FieldSpec>({
       dataParamsByGroupState('adaptation'),
     );
 
-    let fieldParams: any = {};
+    let fieldParams: {
+      eael_days?: number;
+    } = {};
     if (field === 'cost_benefit_ratio') {
       fieldParams = {
         eael_days: get(adaptationCostBenefitRatioEaelDaysState),

--- a/frontend/src/state/layers/view-layers-params.ts
+++ b/frontend/src/state/layers/view-layers-params.ts
@@ -1,6 +1,6 @@
 import { atomFamily, selector, selectorFamily, useRecoilTransaction_UNSTABLE } from 'recoil';
 
-import { ViewLayer, ViewLayerParams } from 'lib/data-map/view-layers';
+import { StyleParams, ViewLayer, ViewLayerParams } from 'lib/data-map/view-layers';
 
 import { viewLayersFlatState } from './view-layers-flat';
 import _ from 'lodash';
@@ -27,7 +27,10 @@ export const singleViewLayerParamsState = selectorFamily<ViewLayerParams, string
     ({ get }) => {
       const viewLayer = get(viewLayerState(viewLayerId));
 
-      const layerParams: any = {};
+      const layerParams: {
+        selection?: ViewLayerParams['selection'];
+        styleParams?: StyleParams;
+      } = {};
 
       if (viewLayer == null) return layerParams;
 

--- a/frontend/src/use-is-mobile.ts
+++ b/frontend/src/use-is-mobile.ts
@@ -1,5 +1,5 @@
-import { useMediaQuery } from '@mui/material';
+import { Theme, useMediaQuery } from '@mui/material';
 
 export function useIsMobile() {
-  return useMediaQuery((theme: any) => theme.breakpoints.down('md'));
+  return useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
 }


### PR DESCRIPTION
Clean up React warnings and some of the TypeScript errors (mostly use of `any` rather than specific types.)