### PR TITLE
fix(frontend): restore region labels

### DIFF
--- a/frontend/src/state/layers/view-layers.ts
+++ b/frontend/src/state/layers/view-layers.ts
@@ -1,5 +1,7 @@
+import { regionLabelsDeckLayer } from 'config/regions/region-labels-deck-layer';
 import { regionBoundariesViewLayer } from 'config/regions/boundaries-view-layer';
 import { ViewLayer, viewOnlyLayer } from 'lib/data-map/view-layers';
+import { backgroundState, showLabelsState } from 'map/layers/layers-state';
 import { selector } from 'recoil';
 import { truthyKeys } from 'lib/helpers';
 import { ConfigTree } from 'lib/nested-config/config-tree';
@@ -49,6 +51,8 @@ export const viewLayersState = selector<ConfigTree<ViewLayer>>({
   get: ({ get }) => {
     const showRegions = get(sectionVisibilityState('regions'));
     const regionLevel = get(regionLevelState);
+    const background = get(backgroundState);
+    const showLabels = get(showLabelsState);
 
     return [
       // administrative region boundaries or population density
@@ -73,6 +77,18 @@ export const viewLayersState = selector<ConfigTree<ViewLayer>>({
       get(droughtOptionsLayerState),
 
       get(featureBoundingBoxLayerState),
+
+      showLabels && [
+        // administrative regions labels
+        showRegions &&
+          viewOnlyLayer(`boundaries_${regionLevel}-text`, () =>
+            regionLabelsDeckLayer(regionLevel, background),
+          ),
+      ],
+
+      /**
+       * CAUTION: for some reason, vector layers put here are obscured by the 'labels' semi-transparent raster layer
+       */
     ];
   },
 });


### PR DESCRIPTION
The move to vector base maps accidentally removed labels for administative regions. This restores them.