### PR TITLE
feat(frontend): aggregated risk map layer (risk hotspots)

### DIFF
--- a/frontend/src/app/config/interaction-groups.ts
+++ b/frontend/src/app/config/interaction-groups.ts
@@ -20,6 +20,14 @@ export const INTERACTION_GROUPS = new Map<string, InteractionGroupConfig>([
     },
   ],
   [
+    'risks',
+    {
+      id: 'risks',
+      type: 'raster',
+      pickMultiple: false,
+    },
+  ],
+  [
     'regions',
     {
       id: 'regions',

--- a/frontend/src/app/config/sections.ts
+++ b/frontend/src/app/config/sections.ts
@@ -5,6 +5,7 @@ import { NETWORK_STYLES } from 'data-layers/networks/styles';
 import { REGION_STYLES } from 'data-layers/regions/styles';
 import { MARINE_STYLES } from 'data-layers/marine/styles';
 import { TERRESTRIAL_STYLES } from 'data-layers/terrestrial/styles';
+import { RISK_STYLES } from 'data-layers/risks/styles';
 
 export const SECTIONS_CONFIG: Record<string, { styles?: Record<string, StyleSelectionOption> }> = {
   assets: {
@@ -14,6 +15,9 @@ export const SECTIONS_CONFIG: Record<string, { styles?: Record<string, StyleSele
     styles: DROUGHT_STYLES,
   },
   hazards: {},
+  risks: {
+    styles: RISK_STYLES,
+  },
   buildings: {
     styles: BUILDING_STYLES,
   },

--- a/frontend/src/app/config/view-layers.ts
+++ b/frontend/src/app/config/view-layers.ts
@@ -4,6 +4,7 @@ export const VIEW_LAYERS = [
   'terrestrial',
   'marine',
   'hazards',
+  'risks',
   'buildings',
   'networks',
   'droughtOptions',

--- a/frontend/src/app/config/views.ts
+++ b/frontend/src/app/config/views.ts
@@ -1,3 +1,5 @@
+import { RISKS_METADATA } from 'data-layers/risks/metadata';
+
 export interface ViewSectionConfig {
   expanded: boolean;
   visible: boolean;
@@ -51,6 +53,13 @@ export const VIEW_SECTIONS: Record<string, Record<string, ViewSectionConfig>> = 
 
       styles: ['type', 'damages'],
       defaultStyle: 'damages',
+    },
+    risks: {
+      expanded: true,
+      visible: true,
+
+      styles: Object.keys(RISKS_METADATA),
+      defaultStyle: Object.keys(RISKS_METADATA)[0],
     },
     hazards: {
       expanded: false,

--- a/frontend/src/app/map/legend/RasterLegend.tsx
+++ b/frontend/src/app/map/legend/RasterLegend.tsx
@@ -1,4 +1,6 @@
-import { FC, useCallback } from 'react';
+import { FC } from 'react';
+
+import { numFormatMoney } from 'lib/helpers';
 import { GradientLegend } from './GradientLegend';
 import { useRasterColorMapValues } from './use-color-map-values';
 export interface ColorValue {
@@ -10,18 +12,31 @@ export interface RasterColorMapValues {
   rangeTruncated: [boolean, boolean];
 }
 
+const formatter = {
+  hazard: (value, dataUnit) => `${value.toLocaleString()} ${dataUnit}`,
+  financial: numFormatMoney,
+  integer: (value) =>
+    value.toLocaleString(undefined, {
+      maximumSignificantDigits: 3,
+      maximumFractionDigits: 0,
+      roundingPriority: 'lessPrecision',
+    }),
+  population: (value) =>
+    value.toLocaleString(undefined, {
+      maximumSignificantDigits: 3,
+    }),
+};
+
 export const RasterLegend: FC<{
   label: string;
   dataUnit: string;
   scheme: string;
   range: [number, number];
-}> = ({ label, dataUnit, scheme, range }) => {
+  type?: string;
+}> = ({ label, dataUnit, scheme, range, type = 'hazard' }) => {
   const { error, loading, colorMapValues } = useRasterColorMapValues(scheme, range);
 
-  const getValueLabel = useCallback(
-    (value: number) => `${value.toLocaleString()} ${dataUnit}`,
-    [dataUnit],
-  );
+  const getValueLabel = (value: number) => formatter[type](value, dataUnit);
 
   return (
     <GradientLegend

--- a/frontend/src/app/map/legend/VectorLegend.tsx
+++ b/frontend/src/app/map/legend/VectorLegend.tsx
@@ -1,6 +1,6 @@
 import { colorScaleValues } from 'lib/color-map';
 import { ColorMap, FormatConfig } from 'lib/data-map/view-layers';
-import { FC, useMemo } from 'react';
+import { FC } from 'react';
 import { GradientLegend } from './GradientLegend';
 
 export const VectorLegend: FC<{ colorMap: ColorMap; legendFormatConfig: FormatConfig }> = ({
@@ -8,15 +8,12 @@ export const VectorLegend: FC<{ colorMap: ColorMap; legendFormatConfig: FormatCo
   legendFormatConfig,
 }) => {
   const { colorSpec, fieldSpec } = colorMap;
-  const colorMapValues = useMemo(() => colorScaleValues(colorSpec, 255), [colorSpec]);
+  const colorMapValues = colorScaleValues(colorSpec, 255);
 
   const { getDataLabel, getValueFormatted } = legendFormatConfig;
 
   const label = getDataLabel(fieldSpec);
-  const getValueLabel = useMemo(
-    () => (value) => getValueFormatted(value, fieldSpec),
-    [fieldSpec, getValueFormatted],
-  );
+  const getValueLabel = (value) => getValueFormatted(value, fieldSpec);
 
   return (
     <GradientLegend

--- a/frontend/src/app/map/tooltip/content/RasterHoverDescription.tsx
+++ b/frontend/src/app/map/tooltip/content/RasterHoverDescription.tsx
@@ -4,6 +4,7 @@ import { useRasterColorMapValues } from '../../legend/use-color-map-values';
 import { ColorBox } from './ColorBox';
 import { Box } from '@mui/material';
 import { DataItem } from 'details/features/detail-components';
+import { numFormatMoney } from 'lib/helpers';
 
 function useRasterColorMapLookup(colorMapValues) {
   return useMemo(
@@ -14,11 +15,26 @@ function useRasterColorMapLookup(colorMapValues) {
   );
 }
 
-function formatHazardValue(color, value, dataUnit) {
+const formatter = {
+  hazard: (value, dataUnit) => value.toFixed(1) + dataUnit,
+  financial: numFormatMoney,
+  integer: (value) =>
+    value.toLocaleString(undefined, {
+      maximumSignificantDigits: 3,
+      maximumFractionDigits: 0,
+      roundingPriority: 'lessPrecision',
+    }),
+  population: (value) =>
+    value.toLocaleString(undefined, {
+      maximumSignificantDigits: 3,
+    }),
+};
+
+function formatValue(color, value, dataUnit, type) {
   return (
     <>
       <ColorBox color={color} />
-      {value == null ? '' : value.toFixed(1) + dataUnit}
+      {value == null ? '' : formatter[type](value, dataUnit)}
     </>
   );
 }
@@ -29,7 +45,8 @@ export const RasterHoverDescription: FC<{
   dataUnit: string;
   scheme: string;
   range: [number, number];
-}> = ({ color, label, dataUnit, scheme, range }) => {
+  type?: string;
+}> = ({ color, label, dataUnit, scheme, range, type = 'hazard' }) => {
   const title = `${label}`;
 
   const { colorMapValues } = useRasterColorMapValues(scheme, range);
@@ -37,9 +54,10 @@ export const RasterHoverDescription: FC<{
 
   const colorString = `rgb(${color[0]},${color[1]},${color[2]})`;
   const value = rasterValueLookup?.[colorString];
+
   return (
     <Box>
-      <DataItem label={title} value={formatHazardValue(colorString, value, dataUnit)} />
+      <DataItem label={title} value={formatValue(colorString, value, dataUnit, type)} />
     </Box>
   );
 };

--- a/frontend/src/app/sidebar/SidebarContent.tsx
+++ b/frontend/src/app/sidebar/SidebarContent.tsx
@@ -9,6 +9,7 @@ import { DroughtsSection } from 'data-layers/droughtRisks/sidebar/DroughtsSectio
 import { HazardsSection } from 'data-layers/hazards/sidebar/HazardsSection';
 import { NetworksSection } from 'data-layers/networks/sidebar/NetworksSection';
 import { RegionsSection } from 'data-layers/regions/sidebar/RegionsSection';
+import { RisksSection } from 'data-layers/risks/sidebar/RisksSection';
 import { MarineSection } from 'data-layers/marine/sidebar/MarineSection';
 import { TerrestrialSection } from 'data-layers/terrestrial/sidebar/TerrestrialSection';
 import { ErrorBoundary } from 'lib/react/ErrorBoundary';
@@ -25,10 +26,19 @@ const SidebarContent: FC = () => {
   const view = useRecoilValue(viewState);
   switch (view) {
     case 'exposure':
+      return (
+        <>
+          <NetworksSection />
+          <HazardsSection />
+          <BuildingsSection />
+          <RegionsSection />
+        </>
+      );
     case 'risk':
       return (
         <>
           <NetworksSection />
+          <RisksSection />
           <HazardsSection />
           <BuildingsSection />
           <RegionsSection />

--- a/frontend/src/app/state/data-params.ts
+++ b/frontend/src/app/state/data-params.ts
@@ -1,5 +1,6 @@
 import { HAZARD_DOMAINS } from 'data-layers/hazards/domains';
 import { NETWORK_DOMAINS } from 'data-layers/networks/domains';
+import { RISK_DOMAINS } from 'data-layers/risks/domains';
 import {
   DataParamGroupConfig,
   Param,
@@ -21,6 +22,7 @@ export type DataParamParam = Readonly<{
 export const dataParamConfig: Record<string, DataParamGroupConfig> = {
   ...HAZARD_DOMAINS,
   ...NETWORK_DOMAINS,
+  risks: RISK_DOMAINS,
 };
 
 export const dataParamNamesByGroup = mapValues(dataParamConfig, (groupConfig) =>

--- a/frontend/src/data-layers/assets/data-formats.ts
+++ b/frontend/src/data-layers/assets/data-formats.ts
@@ -9,15 +9,15 @@ function getSourceLabel(eadSource: string) {
   return HAZARDS_METADATA[eadSource].label;
 }
 
-function getDamageTypeLabel(field) {
+function getDamageTypeLabel(field: string) {
   if (field === 'ead_mean') return 'Direct Damages';
   else if (field === 'eael_mean') return 'Economic Losses';
 }
 
-function formatDamageValue(value) {
+function formatDamageValue(value: number) {
   if (isNullish(value)) return value;
 
-  return `$${numFormatMoney(value)}`;
+  return numFormatMoney(value);
 }
 const DAMAGES_EXPECTED_DEFAULT_FORMAT: FormatConfig = {
   getDataLabel: (colorField) => {

--- a/frontend/src/data-layers/risks/RiskHoverDescription.tsx
+++ b/frontend/src/data-layers/risks/RiskHoverDescription.tsx
@@ -1,0 +1,22 @@
+import { FC } from 'react';
+
+import { RasterHoverDescription } from 'lib/data-map/types';
+import { RasterHoverDescription as RasterTooltip } from 'app/map/tooltip/content/RasterHoverDescription';
+
+import * as RISKS_COLOR_MAPS from './color-maps';
+import { RISKS_METADATA } from './metadata';
+
+export const RiskHoverDescription: FC<RasterHoverDescription> = ({ target, viewLayer }) => {
+  const { label, dataUnit, format } = RISKS_METADATA[viewLayer.id];
+  const { scheme, range } = RISKS_COLOR_MAPS[viewLayer.id];
+  return (
+    <RasterTooltip
+      color={target.color}
+      label={label}
+      dataUnit={dataUnit}
+      scheme={scheme}
+      range={range}
+      type={format}
+    />
+  );
+};

--- a/frontend/src/data-layers/risks/RiskLegend.tsx
+++ b/frontend/src/data-layers/risks/RiskLegend.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react';
+
+import { RasterLegend } from 'app/map/legend/RasterLegend';
+import { ViewLayer } from 'lib/data-map/view-layers';
+
+import * as RISKS_COLOR_MAPS from './color-maps';
+import { RISKS_METADATA } from './metadata';
+
+export const RiskLegend: FC<{ viewLayer: ViewLayer }> = ({ viewLayer }) => {
+  const { id } = viewLayer;
+  const { label, dataUnit, format } = RISKS_METADATA[id];
+  const { scheme, range } = RISKS_COLOR_MAPS[id];
+  return (
+    <RasterLegend label={label} dataUnit={dataUnit} scheme={scheme} range={range} type={format} />
+  );
+};

--- a/frontend/src/data-layers/risks/color-maps.ts
+++ b/frontend/src/data-layers/risks/color-maps.ts
@@ -1,0 +1,28 @@
+/**
+ * Colour scheme and range for exposure values.
+ */
+export const exposureValue = {
+  scheme: 'reds',
+  range: [0, 1e9],
+};
+/**
+ * Colour scheme and range for GDP values.
+ */
+export const lossGdp = {
+  scheme: 'blues',
+  range: [0, 5e6],
+};
+/**
+ * Colour scheme and range for population values.
+ */
+export const populationAffected = {
+  scheme: 'purples',
+  range: [0, 1e4],
+};
+/**
+ * Colour scheme and range for demand values.
+ */
+export const demandAffected = {
+  scheme: 'greens',
+  range: [0, 1e3],
+};

--- a/frontend/src/data-layers/risks/domains.ts
+++ b/frontend/src/data-layers/risks/domains.ts
@@ -1,0 +1,66 @@
+import { DataParamGroupConfig } from 'lib/controls/data-params';
+
+export interface RiskParams {
+  hazard: string;
+  returnPeriod: number;
+  epoch: number;
+  rcp: string;
+  confidence: string | number;
+}
+
+/*
+  Default parameter ranges for each hazard type.
+  These are used to define ranges for input controls in the sidebar.
+*/
+const hazardParamDomains = {
+  none: {
+    returnPeriod: [0],
+    epoch: [2010],
+    rcp: ['baseline'],
+    confidence: ['None'],
+  },
+  cyclone: {
+    returnPeriod: [0],
+    epoch: [2010],
+    rcp: ['baseline'],
+    confidence: ['None'],
+  },
+  fluvial: {
+    returnPeriod: [0],
+    epoch: [2010],
+    rcp: ['baseline'],
+    confidence: ['None'],
+  },
+};
+
+export const RISK_DOMAINS: DataParamGroupConfig<RiskParams> = {
+  /*
+    Default parameter ranges for each risk type.
+  */
+  paramDomains: {
+    hazard: ['none', 'cyclone', 'fluvial'],
+    returnPeriod: [0],
+    epoch: [2010],
+    rcp: ['baseline'],
+    confidence: ['None'],
+  },
+  /*
+    Default parameter values for each risk type.
+  */
+  paramDefaults: {
+    hazard: 'none',
+    returnPeriod: 0,
+    epoch: 2010,
+    rcp: 'baseline',
+    confidence: 'None',
+  },
+  /*
+    Callback functions to define custom parameter ranges based on selected hazard etc.
+  */
+  paramDependencies: {
+    rcp: ({ hazard }) => hazardParamDomains[hazard].rcp,
+    epoch: ({ hazard }) => hazardParamDomains[hazard].epoch,
+    returnPeriod: ({ hazard }) => hazardParamDomains[hazard].returnPeriod,
+    confidence: ({ hazard }) => hazardParamDomains[hazard].confidence,
+  },
+};

--- a/frontend/src/data-layers/risks/metadata.ts
+++ b/frontend/src/data-layers/risks/metadata.ts
@@ -1,0 +1,24 @@
+export const RISKS_METADATA = {
+  demandAffected: {
+    label: 'Demand affected',
+    dataUnit: '',
+    format: 'integer',
+  },
+  exposureValue: {
+    label: 'Exposure value',
+    dataUnit: '',
+    format: 'financial',
+  },
+  populationAffected: {
+    label: 'Population affected',
+    dataUnit: '',
+    format: 'population',
+  },
+  lossGdp: {
+    label: 'Loss GDP',
+    dataUnit: '',
+    format: 'financial',
+  },
+};
+
+export const RISKS = Object.keys(RISKS_METADATA);

--- a/frontend/src/data-layers/risks/risk-view-layer.ts
+++ b/frontend/src/data-layers/risks/risk-view-layer.ts
@@ -1,0 +1,83 @@
+import { createElement } from 'react';
+import GL from '@luma.gl/constants';
+import { RiskParams } from './domains';
+
+import { rasterTileLayer } from 'lib/deck/layers/raster-tile-layer';
+import { ViewLayer } from 'lib/data-map/view-layers';
+import { RasterTarget } from 'lib/data-map/types';
+
+import { RiskLegend } from './RiskLegend';
+import { RiskHoverDescription } from './RiskHoverDescription';
+import * as RISKS_COLOR_MAPS from './color-maps';
+import { RISK_SOURCE } from './source';
+
+export function getRiskId<
+  F extends string, // risk variable
+  RP extends number,
+  RCP extends string,
+  E extends number,
+  C extends number | string,
+>({
+  riskType,
+  hazard,
+  returnPeriod,
+  rcp,
+  epoch,
+  confidence,
+}: {
+  riskType: F;
+  hazard: string;
+  returnPeriod: RP;
+  rcp: RCP;
+  epoch: E;
+  confidence: C;
+}) {
+  return `${riskType}__${hazard}__rp_${returnPeriod}__rcp_${rcp}__epoch_${epoch}__conf_${confidence}` as const;
+}
+
+export function riskViewLayer(riskType: string, riskParams: RiskParams): ViewLayer {
+  const { hazard, returnPeriod, rcp, epoch, confidence } = riskParams;
+
+  const deckId = getRiskId({ riskType, hazard, returnPeriod, rcp, epoch, confidence });
+
+  return {
+    id: riskType,
+    group: 'risks',
+    spatialType: 'raster',
+    interactionGroup: 'risks',
+    params: { riskType, riskParams },
+    fn: ({ deckProps }) => {
+      const { scheme, range } = RISKS_COLOR_MAPS[riskType];
+      const dataURL = RISK_SOURCE.getDataUrl(
+        {
+          riskType,
+        },
+        { scheme, range },
+      );
+
+      return rasterTileLayer(
+        {
+          textureParameters: {
+            [GL.TEXTURE_MAG_FILTER]: GL.LINEAR,
+          },
+          opacity: riskType === 'cyclone' ? 0.6 : 1,
+        },
+        deckProps,
+        {
+          id: `${riskType}@${deckId}`, // follow the convention viewLayerId@deckLayerId
+          data: dataURL,
+          refinementStrategy: 'no-overlap',
+        },
+      );
+    },
+    renderLegend() {
+      return createElement(RiskLegend, {
+        key: riskType,
+        viewLayer: this,
+      });
+    },
+    renderTooltip({ target }: { target: RasterTarget }) {
+      return createElement(RiskHoverDescription, { key: this.id, target, viewLayer: this });
+    },
+  };
+}

--- a/frontend/src/data-layers/risks/sidebar/RisksControl.tsx
+++ b/frontend/src/data-layers/risks/sidebar/RisksControl.tsx
@@ -1,0 +1,32 @@
+import { FormControl, FormControlLabel, FormLabel, Radio, RadioGroup } from '@mui/material';
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import { InputSection } from 'app/sidebar/ui/InputSection';
+import { sectionStyleOptionsState, sectionStyleValueState } from 'app/state/sections';
+
+export const RisksControl = () => {
+  const [value, setValue] = useRecoilState(sectionStyleValueState('risks'));
+  const options = useRecoilValue(sectionStyleOptionsState('risks'));
+  function onChange(event, value) {
+    setValue(value);
+  }
+
+  return (
+    <>
+      <InputSection>
+        <FormControl>
+          <FormLabel>Risk</FormLabel>
+          <RadioGroup value={value} onChange={onChange}>
+            {options.map((option) => (
+              <FormControlLabel
+                key={option.id}
+                label={option.label}
+                control={<Radio value={option.id} />}
+              />
+            ))}
+          </RadioGroup>
+        </FormControl>
+      </InputSection>
+    </>
+  );
+};

--- a/frontend/src/data-layers/risks/sidebar/RisksSection.tsx
+++ b/frontend/src/data-layers/risks/sidebar/RisksSection.tsx
@@ -1,0 +1,19 @@
+import { FC } from 'react';
+
+import { SidebarPanel } from 'app/sidebar/SidebarPanel';
+import { SidebarPanelSection } from 'app/sidebar/ui/SidebarPanelSection';
+import { ErrorBoundary } from 'lib/react/ErrorBoundary';
+
+import { RisksControl } from './RisksControl';
+
+export const RisksSection: FC = () => {
+  return (
+    <SidebarPanel id="risks" title="Aggregated Risk">
+      <ErrorBoundary message="There was a problem displaying this section.">
+        <SidebarPanelSection>
+          <RisksControl />
+        </SidebarPanelSection>
+      </ErrorBoundary>
+    </SidebarPanel>
+  );
+};

--- a/frontend/src/data-layers/risks/source.ts
+++ b/frontend/src/data-layers/risks/source.ts
@@ -1,0 +1,5 @@
+export const RISK_SOURCE = {
+  getDataUrl({ riskType }, { scheme, range }) {
+    return `/raster/singleband/${riskType}/100/baseline/2010/None/{z}/{x}/{y}.png?colormap=${scheme}&stretch_range=[${range[0]},${range[1]}]`;
+  },
+};

--- a/frontend/src/data-layers/risks/state/layer.ts
+++ b/frontend/src/data-layers/risks/state/layer.ts
@@ -1,0 +1,19 @@
+import { ViewLayer } from 'lib/data-map/view-layers';
+import { selector } from 'recoil';
+import { dataParamsByGroupState } from 'app/state/data-params';
+import { sectionVisibilityState } from 'app/state/sections';
+import { sectionStyleValueState } from 'app/state/sections';
+
+import { RiskParams } from '../domains';
+import { riskViewLayer } from '../risk-view-layer';
+
+export const risksLayerState = selector<ViewLayer[]>({
+  key: 'risksLayerState',
+  get: ({ get }) => {
+    const risksStyle = get(sectionStyleValueState('risks'));
+    const dataParams = get(dataParamsByGroupState('risks'));
+    return get(sectionVisibilityState('risks'))
+      ? [riskViewLayer(risksStyle, dataParams as RiskParams)]
+      : [];
+  },
+});

--- a/frontend/src/data-layers/risks/styles.ts
+++ b/frontend/src/data-layers/risks/styles.ts
@@ -1,0 +1,20 @@
+import { makeConfig } from 'lib/helpers';
+
+export const RISK_STYLES = makeConfig([
+  {
+    id: 'demandAffected',
+    label: 'Demand Affected',
+  },
+  {
+    id: 'exposureValue',
+    label: 'Exposure Value',
+  },
+  {
+    id: 'populationAffected',
+    label: 'Population Affected',
+  },
+  {
+    id: 'lossGdp',
+    label: 'Loss GDP',
+  },
+]);

--- a/frontend/src/lib/helpers.ts
+++ b/frontend/src/lib/helpers.ts
@@ -28,6 +28,9 @@ export function numFormatMoney(value: number) {
   return value.toLocaleString(undefined, {
     maximumSignificantDigits: 3,
     maximumFractionDigits: 2,
+    style: 'currency',
+    currency: 'JMD',
+    currencyDisplay: 'narrowSymbol',
   });
 }
 


### PR DESCRIPTION
New raster layer showing aggregated risk values for:
- variables: "exposure value", "population affected", "loss GDP", "demand affected".

Includes:
- New aggregated risk map layer and params in `src/state/layers/modules/risks`.
- New config in `src/config/risks`. Parameters defined in `src/config/risks/domains`.
- New sidebar controls in `src/sidebar/risks`.
- New legends and tooltips in `src/config/risks`.
- Makes a start on generic formats for data values eg. financial or population.
- towards #8.