### PR TITLE
refactor(frontend): concurrent rendering in React 18

### DIFF
--- a/frontend/src/details/adaptations/FeatureAdaptationsTable.tsx
+++ b/frontend/src/details/adaptations/FeatureAdaptationsTable.tsx
@@ -8,7 +8,7 @@ import { getAssetDataFormats } from 'config/assets/data-formats';
 import { FeatureSidebarContent } from 'details/features/FeatureSidebarContent';
 import { BoundingBox, extendBbox } from 'lib/bounding-box';
 import { colorMap } from 'lib/color-map';
-import { mapFitBoundsState } from 'map/MapView';
+import { mapFitBoundsState } from 'lib/map/MapBoundsFitter';
 import { ColorBox } from 'map/tooltip/content/ColorBox';
 import { useCallback, useMemo } from 'react';
 import { atom, useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,5 +1,6 @@
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { App } from './App';
 
 const container = document.getElementById('root');
-render(<App />, container);
+const root = createRoot(container);
+root.render(<App />);

--- a/frontend/src/lib/data-map/BaseMap.tsx
+++ b/frontend/src/lib/data-map/BaseMap.tsx
@@ -1,11 +1,13 @@
 import { MapViewState } from 'deck.gl/typed';
-import { ComponentProps, FC, ReactNode } from 'react';
+import { FC, ReactNode } from 'react';
 import { Map } from 'react-map-gl/maplibre';
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import { backgroundState, showLabelsState } from 'map/layers/layers-state';
+import { useBasemapStyle } from 'map/use-basemap-style';
+import { mapViewStateState } from 'state/map-view/map-view-state';
 
 export interface BaseMapProps {
-  mapStyle: ComponentProps<typeof Map>['mapStyle'];
-  viewState: MapViewState;
-  onViewState: (vs: MapViewState) => void;
   children?: ReactNode;
 }
 
@@ -13,13 +15,22 @@ export interface BaseMapProps {
  * Displays a react-map-gl basemap component.
  * Accepts children such as a DeckGLOverlay, HUD controls etc
  */
-export const BaseMap: FC<BaseMapProps> = ({ mapStyle, viewState, onViewState, children }) => {
+export const BaseMap: FC<BaseMapProps> = ({ children }) => {
+  const background = useRecoilValue(backgroundState);
+  const showLabels = useRecoilValue(showLabelsState);
+  const [viewState, setViewState] = useRecoilState(mapViewStateState);
+  const { mapStyle } = useBasemapStyle(background, showLabels);
+
+  function handleViewStateChange({ viewState }: { viewState: MapViewState }) {
+    setViewState(viewState);
+  }
+
   return (
     <Map
       reuseMaps={true}
       styleDiffing={true}
       {...viewState}
-      onMove={({ viewState }) => onViewState(viewState)}
+      onMove={handleViewStateChange}
       mapStyle={mapStyle}
       dragRotate={false}
       keyboard={false}

--- a/frontend/src/lib/map/MapBoundsFitter.tsx
+++ b/frontend/src/lib/map/MapBoundsFitter.tsx
@@ -1,15 +1,24 @@
 import { WebMercatorViewport } from 'deck.gl/typed';
 import { FC, useEffect } from 'react';
 import { useMap } from 'react-map-gl/maplibre';
+import { atom, useRecoilValue, useResetRecoilState } from 'recoil';
 
 import { BoundingBox, appToDeckBoundingBox } from '../bounding-box';
 
-interface MapBoundsFitterProps {
-  boundingBox: BoundingBox;
-}
+export const mapFitBoundsState = atom<BoundingBox>({
+  key: 'mapFitBoundsState',
+  default: null,
+});
 
-export const MapBoundsFitter: FC<MapBoundsFitterProps> = ({ boundingBox }) => {
+export const MapBoundsFitter: FC = () => {
   const { current: map } = useMap();
+  const boundingBox = useRecoilValue(mapFitBoundsState);
+
+  const resetFitBounds = useResetRecoilState(mapFitBoundsState);
+  useEffect(() => {
+    // reset map fit bounds whenever map is mounted
+    resetFitBounds();
+  }, [resetFitBounds]);
 
   useEffect(() => {
     if (boundingBox != null && map != null) {

--- a/frontend/src/map/MapView.tsx
+++ b/frontend/src/map/MapView.tsx
@@ -1,18 +1,10 @@
-import { Suspense, useCallback, useEffect } from 'react';
-import {
-  atom,
-  useRecoilState,
-  useRecoilValue,
-  useResetRecoilState,
-  useSetRecoilState,
-} from 'recoil';
+import { Suspense, useCallback } from 'react';
+import { useSetRecoilState } from 'recoil';
 
-import { mapViewStateState } from '../state/map-view/map-view-state';
-import { BoundingBox } from 'lib/bounding-box';
 import { BaseMap } from 'lib/data-map/BaseMap';
 import { DataMap } from 'lib/data-map/DataMap';
 import { DataMapTooltip } from 'lib/data-map/DataMapTooltip';
-import { MapBoundsFitter } from 'lib/map/MapBoundsFitter';
+import { MapBoundsFitter, mapFitBoundsState } from 'lib/map/MapBoundsFitter';
 import { MapHud } from 'lib/map/hud/MapHud';
 import { MapHudRegion } from 'lib/map/hud/MapHudRegion';
 import {
@@ -25,22 +17,12 @@ import { PlaceSearchResult } from 'lib/map/place-search/use-place-search';
 import { ErrorBoundary } from 'lib/react/ErrorBoundary';
 import { withProps } from 'lib/react/with-props';
 
-import { interactionGroupsState } from 'state/layers/interaction-groups';
-import { viewLayersFlatState } from 'state/layers/view-layers-flat';
-import { useSaveViewLayers, viewLayersParamsState } from 'state/layers/view-layers-params';
 import { globalStyleVariables } from '../theme';
 import { useIsMobile } from '../use-is-mobile';
 
 import { MapLayerSelection } from './layers/MapLayerSelection';
-import { backgroundState, showLabelsState } from './layers/layers-state';
 import { MapLegend } from './legend/MapLegend';
 import { TooltipContent } from './tooltip/TooltipContent';
-import { useBasemapStyle } from './use-basemap-style';
-
-export const mapFitBoundsState = atom<BoundingBox>({
-  key: 'mapFitBoundsState',
-  default: null,
-});
 
 const AppPlaceSearch = () => {
   const setFitBounds = useSetRecoilState(mapFitBoundsState);
@@ -114,40 +96,12 @@ const MapHudMobileLayout = () => {
 };
 
 const MapViewContent = () => {
-  const [viewState, setViewState] = useRecoilState(mapViewStateState);
-  const background = useRecoilValue(backgroundState);
-  const showLabels = useRecoilValue(showLabelsState);
-  const viewLayers = useRecoilValue(viewLayersFlatState);
-  const saveViewLayers = useSaveViewLayers();
-  const { mapStyle, firstLabelId } = useBasemapStyle(background, showLabels);
-
-  useEffect(() => {
-    saveViewLayers(viewLayers);
-  }, [saveViewLayers, viewLayers]);
-
-  const viewLayersParams = useRecoilValue(viewLayersParamsState);
-
-  const interactionGroups = useRecoilValue(interactionGroupsState);
-
-  const fitBounds = useRecoilValue(mapFitBoundsState);
-
-  const resetFitBounds = useResetRecoilState(mapFitBoundsState);
-  useEffect(() => {
-    // reset map fit bounds whenever MapView is mounted
-    resetFitBounds();
-  }, [resetFitBounds]);
-
   const isMobile = useIsMobile();
 
   return (
-    <BaseMap mapStyle={mapStyle} viewState={viewState} onViewState={setViewState}>
-      <DataMap
-        beforeId={firstLabelId}
-        viewLayers={viewLayers}
-        viewLayersParams={viewLayersParams}
-        interactionGroups={interactionGroups}
-      />
-      <MapBoundsFitter boundingBox={fitBounds} />
+    <BaseMap>
+      <DataMap />
+      <MapBoundsFitter />
       <DataMapTooltip>
         <TooltipContent />
       </DataMapTooltip>


### PR DESCRIPTION
- use the new `createRoot` API in React 18.
- refactor the map layers to avoid an error in React Map GL when the map first mounts (#41.)
- closes #41.