### PR TITLE
refactor(frontend): view layer state

### DIFF
--- a/frontend/src/state/layers/buildings.ts
+++ b/frontend/src/state/layers/buildings.ts
@@ -1,0 +1,17 @@
+import { selector } from 'recoil';
+
+import { ViewLayer } from 'lib/data-map/view-layers';
+import { truthyKeys } from 'lib/helpers';
+import { buildingsViewLayer } from 'config/buildings/buildings-view-layer';
+import { buildingSelectionState } from 'state/buildings';
+import { sectionVisibilityState } from 'state/sections';
+
+export const buildingLayersState = selector<ViewLayer[]>({
+  key: 'buildingLayersState',
+  get: ({ get }) =>
+    get(sectionVisibilityState('buildings'))
+      ? truthyKeys(get(buildingSelectionState)).map((buildingType) =>
+          buildingsViewLayer(buildingType),
+        )
+      : [],
+});

--- a/frontend/src/state/layers/labels.ts
+++ b/frontend/src/state/layers/labels.ts
@@ -1,0 +1,23 @@
+import { selector } from 'recoil';
+
+import { ViewLayer, viewOnlyLayer } from 'lib/data-map/view-layers';
+import { regionLabelsDeckLayer } from 'config/regions/region-labels-deck-layer';
+import { sectionVisibilityState } from 'state/sections';
+import { regionLevelState } from 'state/regions';
+import { backgroundState, showLabelsState } from 'map/layers/layers-state';
+
+export const labelsLayerState = selector<ViewLayer[]>({
+  key: 'labelsLayerState',
+  get: ({ get }) => {
+    const showRegions = get(sectionVisibilityState('regions'));
+    const regionLevel = get(regionLevelState);
+    const background = get(backgroundState);
+    const showLabels = get(showLabelsState);
+    const regionLabelsLayer =
+      showRegions &&
+      viewOnlyLayer(`boundaries_${regionLevel}-text`, () =>
+        regionLabelsDeckLayer(regionLevel, background),
+      );
+    return showLabels && [regionLabelsLayer];
+  },
+});

--- a/frontend/src/state/layers/regions.ts
+++ b/frontend/src/state/layers/regions.ts
@@ -1,0 +1,18 @@
+import { selector } from 'recoil';
+
+import { ViewLayer } from 'lib/data-map/view-layers';
+import { sectionVisibilityState } from 'state/sections';
+import { regionLevelState, showPopulationState } from 'state/regions';
+import { populationViewLayer } from 'config/regions/population-view-layer';
+import { regionBoundariesViewLayer } from 'config/regions/boundaries-view-layer';
+
+export const regionsLayerState = selector<ViewLayer>({
+  key: 'regionsLayerState',
+  get: ({ get }) => {
+    const showRegions = get(sectionVisibilityState('regions'));
+    const showPopulation = get(showPopulationState);
+    const regionLevel = get(regionLevelState);
+    const regionLayer = showPopulation ? populationViewLayer : regionBoundariesViewLayer;
+    return showRegions && regionLayer(regionLevel);
+  },
+});


### PR DESCRIPTION
Move view layer state to separate files for each layer type. Fetch layer state with `waitForAll` to simplify the code.