### PR TITLE
refactor(frontend): generalise TooltipContent

### DIFF
--- a/frontend/src/config/assets/asset-view-layer.ts
+++ b/frontend/src/config/assets/asset-view-layer.ts
@@ -7,6 +7,7 @@ import {
 import { selectableMvtLayer } from 'lib/deck/layers/selectable-mvt-layer';
 import { getAssetDataFormats } from './data-formats';
 import { ASSETS_SOURCE } from './source';
+import { VectorTarget } from 'lib/data-map/interactions/use-interactions';
 
 interface ViewLayerMetadata {
   group: string;
@@ -31,11 +32,13 @@ export function assetViewLayer(
     params: {
       assetId,
     },
-    fn: ({ deckProps, zoom, styleParams, selection }: ViewLayerFunctionOptions) =>
-      selectableMvtLayer(
+    fn: ({ deckProps, zoom, styleParams, selection }: ViewLayerFunctionOptions) => {
+      const target = selection.target as VectorTarget;
+      const selectedFeatureId = target?.feature.id;
+      return selectableMvtLayer(
         {
           selectionOptions: {
-            selectedFeatureId: selection?.target.feature.id,
+            selectedFeatureId,
             polygonOffset: selectionPolygonOffset,
           },
           dataLoaderOptions: {
@@ -47,7 +50,8 @@ export function assetViewLayer(
           data: ASSETS_SOURCE.getDataUrl({ assetId }),
         },
         ...customFn({ zoom, styleParams }),
-      ),
+      );
+    },
     dataAccessFn: customDataAccessFn,
     dataFormatsFn: getAssetDataFormats,
   };

--- a/frontend/src/config/interaction-groups.ts
+++ b/frontend/src/config/interaction-groups.ts
@@ -1,37 +1,51 @@
 import { InteractionGroupConfig } from 'lib/data-map/interactions/use-interactions';
-import { makeConfig } from 'lib/helpers';
 
-export const INTERACTION_GROUPS = makeConfig<InteractionGroupConfig, string>([
-  {
-    id: 'assets',
-    type: 'vector',
-    pickingRadius: 8,
-    pickMultiple: false,
-    usesAutoHighlight: true,
-  },
-  {
-    id: 'hazards',
-    type: 'raster',
-    pickMultiple: true,
-  },
-  {
-    id: 'regions',
-    type: 'vector',
-    pickingRadius: 8,
-    pickMultiple: false,
-  },
-  {
-    id: 'solutions',
-    type: 'vector',
-    pickingRadius: 8,
-    usesAutoHighlight: true,
-    pickMultiple: false,
-  },
-  {
-    id: 'drought',
-    type: 'vector',
-    pickingRadius: 8,
-    usesAutoHighlight: true,
-    pickMultiple: false,
-  },
+export const INTERACTION_GROUPS = new Map<string, InteractionGroupConfig>([
+  [
+    'assets',
+    {
+      id: 'assets',
+      type: 'vector',
+      pickingRadius: 8,
+      pickMultiple: false,
+      usesAutoHighlight: true,
+    },
+  ],
+  [
+    'hazards',
+    {
+      id: 'hazards',
+      type: 'raster',
+      pickMultiple: true,
+    },
+  ],
+  [
+    'regions',
+    {
+      id: 'regions',
+      type: 'vector',
+      pickingRadius: 8,
+      pickMultiple: false,
+    },
+  ],
+  [
+    'solutions',
+    {
+      id: 'solutions',
+      type: 'vector',
+      pickingRadius: 8,
+      usesAutoHighlight: true,
+      pickMultiple: false,
+    },
+  ],
+  [
+    'drought',
+    {
+      id: 'drought',
+      type: 'vector',
+      pickingRadius: 8,
+      usesAutoHighlight: true,
+      pickMultiple: false,
+    },
+  ],
 ]);

--- a/frontend/src/config/regions/population-view-layer.ts
+++ b/frontend/src/config/regions/population-view-layer.ts
@@ -7,6 +7,7 @@ import { featureProperty } from 'lib/deck/props/data-source';
 import { border, fillColor } from 'lib/deck/props/style';
 import { RegionLevel } from './metadata';
 import { REGIONS_SOURCE } from './source';
+import { VectorTarget } from 'lib/data-map/interactions/use-interactions';
 
 export function populationViewLayer(regionLevel: RegionLevel): ViewLayer {
   const source = REGIONS_SOURCE;
@@ -35,9 +36,11 @@ export function populationViewLayer(regionLevel: RegionLevel): ViewLayer {
       getDataLabel: () => 'Population density',
       getValueFormatted: (value: number) => `${value.toLocaleString()}/km²`,
     }),
-    fn: ({ deckProps, zoom, selection }) =>
-      selectableMvtLayer(
-        { selectionOptions: { selectedFeatureId: selection?.target.feature.id } },
+    fn: ({ deckProps, zoom, selection }) => {
+      const target = selection.target as VectorTarget;
+      const selectedFeatureId = target?.feature.id;
+      return selectableMvtLayer(
+        { selectionOptions: { selectedFeatureId } },
         deckProps,
         {
           data: source.getDataUrl({ regionLevel }),
@@ -47,6 +50,7 @@ export function populationViewLayer(regionLevel: RegionLevel): ViewLayer {
         {
           highlightColor: [0, 255, 255, 100],
         },
-      ),
+      );
+    },
   };
 }

--- a/frontend/src/details/features/FeatureSidebar.tsx
+++ b/frontend/src/details/features/FeatureSidebar.tsx
@@ -8,6 +8,7 @@ import { ErrorBoundary } from 'lib/react/ErrorBoundary';
 import { Box } from '@mui/system';
 import { DeselectButton } from 'details/DeselectButton';
 import { MobileTabContentWatcher } from 'pages/map/layouts/mobile/tab-has-content';
+import { InteractionTarget, VectorTarget } from 'lib/data-map/interactions/use-interactions';
 
 export const FeatureSidebar: FC = () => {
   const featureSelection = useRecoilValue(selectionState('assets'));
@@ -17,7 +18,7 @@ export const FeatureSidebar: FC = () => {
   const {
     target: { feature },
     viewLayer,
-  } = featureSelection;
+  } = featureSelection as InteractionTarget<VectorTarget>;
 
   return (
     <SidePanel position="relative">

--- a/frontend/src/details/solutions/SolutionsSidebar.tsx
+++ b/frontend/src/details/solutions/SolutionsSidebar.tsx
@@ -7,6 +7,7 @@ import { FC } from 'react';
 import { useRecoilValue } from 'recoil';
 import { SolutionsSidebarContent } from './SolutionsSidebarContent';
 import { MobileTabContentWatcher } from 'pages/map/layouts/mobile/tab-has-content';
+import { InteractionTarget, VectorTarget } from 'lib/data-map/interactions/use-interactions';
 
 export const SolutionsSidebar: FC = () => {
   const featureSelection = useRecoilValue(selectionState('solutions'));
@@ -16,7 +17,7 @@ export const SolutionsSidebar: FC = () => {
   const {
     target: { feature },
     viewLayer,
-  } = featureSelection;
+  } = featureSelection as InteractionTarget<VectorTarget>;
 
   return (
     <SidePanel position="relative">

--- a/frontend/src/lib/data-map/interactions/interaction-state.ts
+++ b/frontend/src/lib/data-map/interactions/interaction-state.ts
@@ -3,9 +3,10 @@ import { atom, atomFamily, selector } from 'recoil';
 
 import { isReset } from 'lib/recoil/is-reset';
 
-import { InteractionTarget } from './use-interactions';
+import { InteractionTarget, RasterTarget, VectorTarget } from './use-interactions';
 
-type IT = InteractionTarget<any> | InteractionTarget<any>[];
+type InteractionLayer = InteractionTarget<VectorTarget> | InteractionTarget<RasterTarget>;
+type IT = InteractionLayer | InteractionLayer[];
 
 export function hasHover(target: IT) {
   if (Array.isArray(target)) {
@@ -24,7 +25,7 @@ export const hoverPositionState = atom({
   default: null,
 });
 
-export const selectionState = atomFamily<InteractionTarget<any>, string>({
+export const selectionState = atomFamily<InteractionLayer, string>({
   key: 'selectionState',
   default: null,
 });

--- a/frontend/src/lib/data-map/interactions/use-interactions.ts
+++ b/frontend/src/lib/data-map/interactions/use-interactions.ts
@@ -85,21 +85,21 @@ function processPickedObject(
   const viewLayerId = lookupViewForDeck(deckLayerId);
   const target = processTargetByType(type, info);
 
-  return (
-    target && {
-      interactionGroup: groupName,
-      interactionStyle: type,
-      viewLayer: viewLayerLookup(viewLayerId),
-      target,
-    }
-  );
+  return (target && {
+    interactionGroup: groupName,
+    interactionStyle: type,
+    viewLayer: viewLayerLookup(viewLayerId),
+    target,
+  }) as InteractionLayer;
 }
 
+type InteractionLayer = InteractionTarget<VectorTarget> | InteractionTarget<RasterTarget>;
+
 function useSetInteractionGroupState(
-  stateFamily: RecoilStateFamily<InteractionTarget<any> | InteractionTarget<any>[], string>,
+  stateFamily: RecoilStateFamily<InteractionLayer | InteractionLayer[], string>,
 ) {
   return useRecoilCallback(({ set }) => {
-    return (groupName: string, value: InteractionTarget<any> | InteractionTarget<any>[]) => {
+    return (groupName: string, value: InteractionLayer | InteractionLayer[]) => {
       set(stateFamily(groupName), value);
     };
   });
@@ -147,7 +147,7 @@ export function useInteractions(
 
         if (pickMultiple) {
           const pickedObjects: PickInfo<any>[] = deck.pickMultipleObjects(pickingParams);
-          const interactionTargets: InteractionTarget<any>[] = pickedObjects
+          const interactionTargets: InteractionLayer[] = pickedObjects
             .map((info) =>
               processPickedObject(info, type, groupName, viewLayerLookup, lookupViewForDeck),
             )
@@ -156,7 +156,7 @@ export function useInteractions(
           setInteractionGroupHover(groupName, interactionTargets);
         } else {
           const info: PickInfo<any> = deck.pickObject(pickingParams);
-          const interactionTarget: InteractionTarget<any> =
+          const interactionTarget: InteractionLayer =
             info && processPickedObject(info, type, groupName, viewLayerLookup, lookupViewForDeck);
 
           setInteractionGroupHover(groupName, interactionTarget);

--- a/frontend/src/lib/data-map/view-layers.ts
+++ b/frontend/src/lib/data-map/view-layers.ts
@@ -1,7 +1,7 @@
 import { ScaleSequential } from 'd3-scale';
 import { DataLoader } from 'lib/data-loader/data-loader';
 import { Accessor } from 'lib/deck/props/getters';
-import { InteractionTarget } from './interactions/use-interactions';
+import { InteractionTarget, VectorTarget, RasterTarget } from './interactions/use-interactions';
 
 export interface FieldSpec {
   fieldGroup: string;
@@ -30,7 +30,7 @@ export interface ViewLayerFunctionOptions {
   deckProps: any;
   zoom: number;
   styleParams?: StyleParams;
-  selection?: InteractionTarget<any>;
+  selection?: InteractionTarget<VectorTarget> | InteractionTarget<RasterTarget>;
 }
 
 export interface DataManager {

--- a/frontend/src/map/tooltip/TooltipContent.tsx
+++ b/frontend/src/map/tooltip/TooltipContent.tsx
@@ -6,11 +6,21 @@ import { VectorHoverDescription } from './content/VectorHoverDescription';
 import { RasterHoverDescription } from './content/RasterHoverDescription';
 import { RegionHoverDescription } from './content/RegionHoverDescription';
 import { hasHover, hoverState } from 'lib/data-map/interactions/interaction-state';
-import { InteractionTarget } from 'lib/data-map/interactions/use-interactions';
+import {
+  InteractionTarget,
+  VectorTarget,
+  RasterTarget,
+} from 'lib/data-map/interactions/use-interactions';
 import { showPopulationState } from 'state/regions';
 import { SolutionHoverDescription } from './content/SolutionHoverDescription';
 import { DroughtHoverDescription } from './content/DroughtHoverDescription';
 import { ErrorBoundary } from 'lib/react/ErrorBoundary';
+
+type MapDataLayer = InteractionTarget<VectorTarget | RasterTarget>;
+type TooltipLayer = {
+  component: FC<{ hoveredObject: MapDataLayer }>;
+  target: MapDataLayer | MapDataLayer[] | null;
+};
 
 const TooltipSection = ({ children }) => (
   <Box p={1} borderBottom="1px solid #ccc">
@@ -18,26 +28,64 @@ const TooltipSection = ({ children }) => (
   </Box>
 );
 
-export const TooltipContent: FC = () => {
-  const hoveredVector = useRecoilValue(hoverState('assets')) as InteractionTarget<any>;
-  const hoveredRasters = useRecoilValue(hoverState('hazards')) as InteractionTarget<any>[];
-  const hoveredRegion = useRecoilValue(hoverState('regions')) as InteractionTarget<any>;
-  const hoveredSolution = useRecoilValue(hoverState('solutions')) as InteractionTarget<any>;
-  const hoveredDrought = useRecoilValue(hoverState('drought')) as InteractionTarget<any>;
+const useLayerTarget = (layerId: string) => useRecoilValue(hoverState(layerId));
+/**
+ * Define tooltip properties for data layers.
+ * @returns a map of tooltip components and their respective data layers, mapped by layer ID.
+ */
+function useTooltipLayers(): Map<string, TooltipLayer> {
+  return new Map<string, TooltipLayer>([
+    [
+      'assets',
+      {
+        component: VectorHoverDescription,
+        target: useLayerTarget('assets'),
+      },
+    ],
+    [
+      'hazards',
+      {
+        component: RasterHoverDescription,
+        target: useLayerTarget('hazards'),
+      },
+    ],
+    [
+      'regions',
+      {
+        component: RegionHoverDescription,
+        target: useLayerTarget('regions'),
+      },
+    ],
+    [
+      'solutions',
+      {
+        component: SolutionHoverDescription,
+        target: useLayerTarget('solutions'),
+      },
+    ],
+    [
+      'drought',
+      {
+        component: DroughtHoverDescription,
+        target: useLayerTarget('drought'),
+      },
+    ],
+  ]);
+}
 
+export const TooltipContent: FC = () => {
+  const layers = useTooltipLayers();
+  const layerEntries = [...layers.entries()];
   const regionDataShown = useRecoilValue(showPopulationState);
 
-  const assetsHovered = hasHover(hoveredVector);
-  const hazardsHovered = hasHover(hoveredRasters);
-  const regionsHovered = hasHover(hoveredRegion);
-  const solutionsHovered = hasHover(hoveredSolution);
-  const droughtHovered = hasHover(hoveredDrought);
-  const doShow =
-    assetsHovered ||
-    hazardsHovered ||
-    (regionDataShown && regionsHovered) ||
-    solutionsHovered ||
-    droughtHovered;
+  function hasHovered([type, { target }]) {
+    if (type === 'regions' && !regionDataShown) {
+      return false;
+    }
+    return hasHover(target);
+  }
+
+  const doShow = layerEntries.some(hasHovered);
 
   if (!doShow) return null;
 
@@ -45,36 +93,26 @@ export const TooltipContent: FC = () => {
     <Paper>
       <Box minWidth={200}>
         <ErrorBoundary message="There was a problem displaying the tooltip.">
-          {solutionsHovered && (
-            <TooltipSection>
-              <SolutionHoverDescription hoveredObject={hoveredSolution} />
-            </TooltipSection>
-          )}
-          {assetsHovered ? (
-            <TooltipSection>
-              <VectorHoverDescription hoveredObject={hoveredVector} />
-            </TooltipSection>
-          ) : null}
-          {droughtHovered ? (
-            <TooltipSection>
-              <DroughtHoverDescription hoveredObject={hoveredDrought} />
-            </TooltipSection>
-          ) : null}
-          {hazardsHovered ? (
-            <TooltipSection>
-              {hoveredRasters.map((hr) => (
-                <RasterHoverDescription
-                  hoveredObject={hr}
-                  key={`${hr.viewLayer.id}-${hr.target.id}`}
-                />
-              ))}
-            </TooltipSection>
-          ) : null}
-          {regionsHovered ? (
-            <TooltipSection>
-              <RegionHoverDescription hoveredObject={hoveredRegion} />
-            </TooltipSection>
-          ) : null}
+          {layerEntries.map((layer) => {
+            const [type, { component: Component, target }] = layer;
+            if (hasHovered(layer)) {
+              if (Array.isArray(target)) {
+                return (
+                  <TooltipSection key={type}>
+                    {target.map((hr) => (
+                      <Component hoveredObject={hr} key={hr.viewLayer.id} />
+                    ))}
+                  </TooltipSection>
+                );
+              }
+              return (
+                <TooltipSection key={type}>
+                  <Component hoveredObject={target} />
+                </TooltipSection>
+              );
+            }
+            return null;
+          })}
         </ErrorBoundary>
       </Box>
     </Paper>

--- a/frontend/src/state/layers/drought.ts
+++ b/frontend/src/state/layers/drought.ts
@@ -12,6 +12,7 @@ import {
   DROUGHT_RISK_VARIABLES_WITH_RCP,
 } from 'config/drought/metadata';
 import { colorMap } from 'lib/color-map';
+import { VectorTarget } from 'lib/data-map/interactions/use-interactions';
 import { ColorSpec, FieldSpec, ViewLayer } from 'lib/data-map/view-layers';
 import { selectableMvtLayer } from 'lib/deck/layers/selectable-mvt-layer';
 import { dataColorMap } from 'lib/deck/props/color-map';
@@ -87,11 +88,13 @@ export const droughtRegionsLayerState = selector<ViewLayer>({
         },
       },
 
-      fn: ({ deckProps, selection }) =>
-        selectableMvtLayer(
+      fn: ({ deckProps, selection }) => {
+        const target = selection.target as VectorTarget;
+        const selectedFeatureId = target?.feature.id;
+        return selectableMvtLayer(
           {
             selectionOptions: {
-              selectedFeatureId: selection?.target?.feature.id,
+              selectedFeatureId,
             },
           },
           deckProps,
@@ -102,7 +105,8 @@ export const droughtRegionsLayerState = selector<ViewLayer>({
           },
           border([255, 255, 255]),
           fillColor(dataColorMap(dataFn, colorFn)),
-        ),
+        );
+      },
     };
   },
 });
@@ -168,11 +172,13 @@ export const droughtOptionsLayerState = selector<ViewLayer>({
           colorSpec,
         },
       },
-      fn: ({ deckProps, selection, zoom }) =>
+      fn: ({ deckProps, selection, zoom }) => {
+        const target = selection.target as VectorTarget;
+        const selectedFeatureId = target?.feature.id;
         selectableMvtLayer(
           {
             selectionOptions: {
-              selectedFeatureId: selection?.target?.feature.id,
+              selectedFeatureId,
             },
           },
           deckProps,
@@ -184,7 +190,8 @@ export const droughtOptionsLayerState = selector<ViewLayer>({
           pointRadius(zoom),
           border([255, 255, 255]),
           fillColor(dataColorMap(dataFn, colorFn)),
-        ),
+        );
+      },
     };
   },
 });

--- a/frontend/src/state/layers/interaction-groups.ts
+++ b/frontend/src/state/layers/interaction-groups.ts
@@ -6,16 +6,11 @@ export const interactionGroupsState = selector({
   key: 'interactionGroupsState',
   get: ({ get }) => {
     const regionDataShown = get(showPopulationState);
+    if (INTERACTION_GROUPS.has('regions')) {
+      const regionsGroup = INTERACTION_GROUPS.get('regions');
+      INTERACTION_GROUPS.set('regions', { ...regionsGroup, usesAutoHighlight: regionDataShown });
+    }
 
-    return [
-      INTERACTION_GROUPS.assets,
-      INTERACTION_GROUPS.hazards,
-      {
-        ...INTERACTION_GROUPS.regions,
-        usesAutoHighlight: regionDataShown,
-      },
-      INTERACTION_GROUPS.solutions,
-      INTERACTION_GROUPS.drought,
-    ];
+    return INTERACTION_GROUPS;
   },
 });

--- a/frontend/src/state/layers/marine.ts
+++ b/frontend/src/state/layers/marine.ts
@@ -9,6 +9,7 @@ import { fillColor } from 'lib/deck/props/style';
 import { Accessor } from 'lib/deck/props/getters';
 import { marineFiltersState } from 'state/solutions/marine-filters';
 import { selectableMvtLayer } from 'lib/deck/layers/selectable-mvt-layer';
+import { VectorTarget } from 'lib/data-map/interactions/use-interactions';
 
 export function habitatColorMap(x: string) {
   return MARINE_HABITAT_COLORS[x]?.css ?? MARINE_HABITAT_COLORS['other'].css;
@@ -71,10 +72,12 @@ export const marineLayerState = selector<ViewLayer>({
       group: null,
       interactionGroup: 'solutions',
       fn: ({ deckProps, selection }) => {
+        const target = selection.target as VectorTarget;
+        const selectedFeatureId = target?.feature.id;
         return selectableMvtLayer(
           {
             selectionOptions: {
-              selectedFeatureId: selection?.target?.feature.id,
+              selectedFeatureId,
               polygonOffset: -3000,
             },
           },

--- a/frontend/src/state/layers/terrestrial.ts
+++ b/frontend/src/state/layers/terrestrial.ts
@@ -20,6 +20,7 @@ import { selectableMvtLayer } from 'lib/deck/layers/selectable-mvt-layer';
 import { getTerrestrialDataFormats } from 'config/solutions/data-formats';
 import { getSolutionsDataAccessor } from 'config/solutions/data-access';
 import { landuseFilterState } from 'state/solutions/landuse-tree';
+import { VectorTarget } from 'lib/data-map/interactions/use-interactions';
 
 export function landuseColorMap(x: string) {
   return TERRESTRIAL_LANDUSE_COLORS[x].css;
@@ -170,12 +171,14 @@ export const terrestrialLayerState = selector<ViewLayer>({
       dataFormatsFn: getTerrestrialDataFormats,
       fn: ({ deckProps, zoom, selection }) => {
         const switchoverZoom = 14.5;
+        const target = selection.target as VectorTarget;
+        const selectedFeatureId = target?.feature.id;
 
         return [
           selectableMvtLayer(
             {
               selectionOptions: {
-                selectedFeatureId: selection?.target?.feature.id,
+                selectedFeatureId,
                 polygonOffset: -1000,
               },
             },
@@ -206,7 +209,7 @@ export const terrestrialLayerState = selector<ViewLayer>({
           selectableMvtLayer(
             {
               selectionOptions: {
-                selectedFeatureId: selection?.target?.feature.id,
+                selectedFeatureId,
                 polygonOffset: -1000,
               },
             },


### PR DESCRIPTION
Generalise TooltipContent with a `useTooltipLayers` hook, which supplies a map of layer IDs to their respective tooltip components and layer state. This should make it easier to add new layers, by extending the map.

Refactor interaction groups as a dynamic map. Add/remove new interactive layers by adding entries to/removing entries from `src/config/interaction-groups`.