### PR TITLE
refactor(frontend): raster layer metadata

### DIFF
--- a/frontend/src/map/legend/RasterLegend.tsx
+++ b/frontend/src/map/legend/RasterLegend.tsx
@@ -13,12 +13,14 @@ export interface RasterColorMapValues {
   rangeTruncated: [boolean, boolean];
 }
 
+const metadata = {
+  ...HAZARDS_METADATA,
+};
+
 export const RasterLegend: FC<{ viewLayer: ViewLayer }> = ({ viewLayer }) => {
-  const {
-    params: { hazardType },
-  } = viewLayer;
-  const { label, dataUnit } = HAZARDS_METADATA[hazardType];
-  const { scheme, range } = RASTER_COLOR_MAPS[hazardType];
+  const { id } = viewLayer;
+  const { label, dataUnit } = metadata[id];
+  const { scheme, range } = RASTER_COLOR_MAPS[id];
 
   const { error, loading, colorMapValues } = useRasterColorMapValues(scheme, range);
 

--- a/frontend/src/map/tooltip/TooltipContent.tsx
+++ b/frontend/src/map/tooltip/TooltipContent.tsx
@@ -19,7 +19,6 @@ const TooltipSection = ({ children }) => (
   </Box>
 );
 
-
 const tooltipLayers: Map<string, FC<{ hoveredObject: MapDataLayer }>> = new Map<
   string,
   FC<{ hoveredObject: MapDataLayer }>

--- a/frontend/src/map/tooltip/content/RasterHoverDescription.tsx
+++ b/frontend/src/map/tooltip/content/RasterHoverDescription.tsx
@@ -28,19 +28,20 @@ function formatHazardValue(color, value, dataUnit) {
   );
 }
 
+const metadata = {
+  ...HAZARDS_METADATA,
+};
+
 export const RasterHoverDescription: FC<{ hoveredObject: InteractionTarget<RasterTarget> }> = ({
   hoveredObject,
 }) => {
   const { color } = hoveredObject.target;
 
   const {
-    viewLayer: {
-      id,
-      params: { hazardType },
-    },
+    viewLayer: { id },
   } = hoveredObject;
-  const { label, dataUnit } = HAZARDS_METADATA[id];
-  const { scheme, range } = RASTER_COLOR_MAPS[hazardType];
+  const { label, dataUnit } = metadata[id];
+  const { scheme, range } = RASTER_COLOR_MAPS[id];
 
   const title = `${label}`;
 


### PR DESCRIPTION
Refactor raster layer metadata for tooltips and legends, so that it isn't hardcoded to hazards.