### PR TITLE
fix(frontend): layer selection crashes map

### DIFF
--- a/frontend/src/config/assets/asset-view-layer.ts
+++ b/frontend/src/config/assets/asset-view-layer.ts
@@ -33,7 +33,7 @@ export function assetViewLayer(
       assetId,
     },
     fn: ({ deckProps, zoom, styleParams, selection }: ViewLayerFunctionOptions) => {
-      const target = selection.target as VectorTarget;
+      const target = selection?.target as VectorTarget;
       const selectedFeatureId = target?.feature.id;
       return selectableMvtLayer(
         {

--- a/frontend/src/config/regions/population-view-layer.ts
+++ b/frontend/src/config/regions/population-view-layer.ts
@@ -37,7 +37,7 @@ export function populationViewLayer(regionLevel: RegionLevel): ViewLayer {
       getValueFormatted: (value: number) => `${value.toLocaleString()}/km²`,
     }),
     fn: ({ deckProps, zoom, selection }) => {
-      const target = selection.target as VectorTarget;
+      const target = selection?.target as VectorTarget;
       const selectedFeatureId = target?.feature.id;
       return selectableMvtLayer(
         { selectionOptions: { selectedFeatureId } },

--- a/frontend/src/state/layers/drought.ts
+++ b/frontend/src/state/layers/drought.ts
@@ -89,7 +89,7 @@ export const droughtRegionsLayerState = selector<ViewLayer>({
       },
 
       fn: ({ deckProps, selection }) => {
-        const target = selection.target as VectorTarget;
+        const target = selection?.target as VectorTarget;
         const selectedFeatureId = target?.feature.id;
         return selectableMvtLayer(
           {
@@ -173,7 +173,7 @@ export const droughtOptionsLayerState = selector<ViewLayer>({
         },
       },
       fn: ({ deckProps, selection, zoom }) => {
-        const target = selection.target as VectorTarget;
+        const target = selection?.target as VectorTarget;
         const selectedFeatureId = target?.feature.id;
         selectableMvtLayer(
           {

--- a/frontend/src/state/layers/marine.ts
+++ b/frontend/src/state/layers/marine.ts
@@ -72,7 +72,7 @@ export const marineLayerState = selector<ViewLayer>({
       group: null,
       interactionGroup: 'solutions',
       fn: ({ deckProps, selection }) => {
-        const target = selection.target as VectorTarget;
+        const target = selection?.target as VectorTarget;
         const selectedFeatureId = target?.feature.id;
         return selectableMvtLayer(
           {

--- a/frontend/src/state/layers/terrestrial.ts
+++ b/frontend/src/state/layers/terrestrial.ts
@@ -171,7 +171,7 @@ export const terrestrialLayerState = selector<ViewLayer>({
       dataFormatsFn: getTerrestrialDataFormats,
       fn: ({ deckProps, zoom, selection }) => {
         const switchoverZoom = 14.5;
-        const target = selection.target as VectorTarget;
+        const target = selection?.target as VectorTarget;
         const selectedFeatureId = target?.feature.id;
 
         return [


### PR DESCRIPTION
Restore some existential checks that were removed in #44. Without them, the map crashes when certain layers are selected in the sidebar.