### PR TITLE
refactor(frontend): refactor vector view layers

### DIFF
--- a/frontend/src/config/assets/asset-view-layer.ts
+++ b/frontend/src/config/assets/asset-view-layer.ts
@@ -1,3 +1,5 @@
+import { createElement } from 'react';
+
 import {
   StyleParams,
   ViewLayer,
@@ -6,8 +8,10 @@ import {
 } from 'lib/data-map/view-layers';
 import { VectorTarget } from 'lib/data-map/types';
 import { selectableMvtLayer } from 'lib/deck/layers/selectable-mvt-layer';
+
 import { getAssetDataFormats } from './data-formats';
 import { ASSETS_SOURCE } from './source';
+import { AssetHoverDescription } from './AssetHoverDescription';
 
 interface ViewLayerMetadata {
   group: string;
@@ -54,5 +58,8 @@ export function assetViewLayer(
     },
     dataAccessFn: customDataAccessFn,
     dataFormatsFn: getAssetDataFormats,
+    renderTooltip({ target }: { target: VectorTarget }) {
+      return createElement(AssetHoverDescription, { key: this.id, target, viewLayer: this });
+    },
   };
 }

--- a/frontend/src/config/drought/drought-options-view-layer.ts
+++ b/frontend/src/config/drought/drought-options-view-layer.ts
@@ -1,0 +1,54 @@
+import { createElement } from 'react';
+
+import { ASSETS_SOURCE } from 'config/assets/source';
+import { colorMap } from 'lib/color-map';
+import { ViewLayer } from 'lib/data-map/view-layers';
+import { VectorTarget } from 'lib/data-map/types';
+import { selectableMvtLayer } from 'lib/deck/layers/selectable-mvt-layer';
+import { border, fillColor, pointRadius } from 'lib/deck/props/style';
+import { dataColorMap } from 'lib/deck/props/color-map';
+
+import { getDroughtDataAccessor } from './data-access';
+import { getDroughtOptionsDataFormats } from './data-formats';
+import { DroughtHoverDescription } from './DroughtHoverDescription';
+
+export function droughtOptionsViewLayer({ fieldSpec, colorSpec }): ViewLayer {
+  const dataFn = getDroughtDataAccessor(fieldSpec);
+  const colorFn = colorMap(colorSpec);
+  return {
+    id: 'drought_options',
+    group: null,
+    interactionGroup: 'drought',
+    dataAccessFn: getDroughtDataAccessor,
+    dataFormatsFn: getDroughtOptionsDataFormats,
+    styleParams: {
+      colorMap: {
+        fieldSpec,
+        colorSpec,
+      },
+    },
+    fn: ({ deckProps, selection, zoom }) => {
+      const target = selection?.target as VectorTarget;
+      const selectedFeatureId = target?.feature.id;
+      selectableMvtLayer(
+        {
+          selectionOptions: {
+            selectedFeatureId,
+          },
+        },
+        deckProps,
+        {
+          data: ASSETS_SOURCE.getDataUrl({ assetId: 'drought_options' }),
+
+          filled: true,
+        },
+        pointRadius(zoom),
+        border([255, 255, 255]),
+        fillColor(dataColorMap(dataFn, colorFn)),
+      );
+    },
+    renderTooltip({ target }: { target: VectorTarget }) {
+      return createElement(DroughtHoverDescription, { key: this.id, target, viewLayer: this });
+    },
+  };
+}

--- a/frontend/src/config/drought/drought-risk-view-layer.ts
+++ b/frontend/src/config/drought/drought-risk-view-layer.ts
@@ -1,0 +1,54 @@
+import { createElement } from 'react';
+
+import { ASSETS_SOURCE } from 'config/assets/source';
+import { colorMap } from 'lib/color-map';
+import { ViewLayer } from 'lib/data-map/view-layers';
+import { VectorTarget } from 'lib/data-map/types';
+import { selectableMvtLayer } from 'lib/deck/layers/selectable-mvt-layer';
+import { border, fillColor } from 'lib/deck/props/style';
+import { dataColorMap } from 'lib/deck/props/color-map';
+
+import { getDroughtDataAccessor } from './data-access';
+import { getDroughtRiskDataFormats } from './data-formats';
+import { DroughtHoverDescription } from './DroughtHoverDescription';
+
+export function droughtRiskViewLayer({ fieldSpec, colorSpec }): ViewLayer {
+  const dataFn = getDroughtDataAccessor(fieldSpec);
+  const colorFn = colorMap(colorSpec);
+  return {
+    id: 'drought_risk',
+    group: null,
+    interactionGroup: 'drought',
+    dataAccessFn: getDroughtDataAccessor,
+    dataFormatsFn: getDroughtRiskDataFormats,
+    styleParams: {
+      colorMap: {
+        fieldSpec,
+        colorSpec,
+      },
+    },
+
+    fn: ({ deckProps, selection }) => {
+      const target = selection?.target as VectorTarget;
+      const selectedFeatureId = target?.feature.id;
+      return selectableMvtLayer(
+        {
+          selectionOptions: {
+            selectedFeatureId,
+          },
+        },
+        deckProps,
+        {
+          data: ASSETS_SOURCE.getDataUrl({ assetId: 'drought_combined' }),
+
+          filled: true,
+        },
+        border([255, 255, 255]),
+        fillColor(dataColorMap(dataFn, colorFn)),
+      );
+    },
+    renderTooltip({ target }: { target: VectorTarget }) {
+      return createElement(DroughtHoverDescription, { key: this.id, target, viewLayer: this });
+    },
+  };
+}

--- a/frontend/src/config/interaction-groups.ts
+++ b/frontend/src/config/interaction-groups.ts
@@ -1,10 +1,5 @@
 import { InteractionGroupConfig } from 'lib/data-map/types';
 
-import { AssetHoverDescription } from './assets/AssetHoverDescription';
-import { SolutionHoverDescription } from './solutions/SolutionHoverDescription';
-import { RegionHoverDescription } from './regions/RegionHoverDescription';
-import { DroughtHoverDescription } from './drought/DroughtHoverDescription';
-
 export const INTERACTION_GROUPS = new Map<string, InteractionGroupConfig>([
   [
     'assets',
@@ -14,7 +9,6 @@ export const INTERACTION_GROUPS = new Map<string, InteractionGroupConfig>([
       pickingRadius: 8,
       pickMultiple: false,
       usesAutoHighlight: true,
-      Component: AssetHoverDescription,
     },
   ],
   [
@@ -32,7 +26,6 @@ export const INTERACTION_GROUPS = new Map<string, InteractionGroupConfig>([
       type: 'vector',
       pickingRadius: 8,
       pickMultiple: false,
-      Component: RegionHoverDescription,
     },
   ],
   [
@@ -43,7 +36,6 @@ export const INTERACTION_GROUPS = new Map<string, InteractionGroupConfig>([
       pickingRadius: 8,
       usesAutoHighlight: true,
       pickMultiple: false,
-      Component: SolutionHoverDescription,
     },
   ],
   [
@@ -54,7 +46,6 @@ export const INTERACTION_GROUPS = new Map<string, InteractionGroupConfig>([
       pickingRadius: 8,
       usesAutoHighlight: true,
       pickMultiple: false,
-      Component: DroughtHoverDescription,
     },
   ],
 ]);

--- a/frontend/src/config/regions/boundaries-view-layer.ts
+++ b/frontend/src/config/regions/boundaries-view-layer.ts
@@ -1,6 +1,11 @@
+import { createElement } from 'react';
+
+import { VectorTarget } from 'lib/data-map/types';
+import { ViewLayer } from 'lib/data-map/view-layers';
+
 import { regionBoundariesDeckLayer } from './region-boundaries-deck-layer';
 import { RegionLevel } from './metadata';
-import { ViewLayer } from 'lib/data-map/view-layers';
+import { RegionHoverDescription } from './RegionHoverDescription';
 
 export function regionBoundariesViewLayer(regionLevel: RegionLevel): ViewLayer {
   return {
@@ -12,5 +17,8 @@ export function regionBoundariesViewLayer(regionLevel: RegionLevel): ViewLayer {
       regionLevel,
     },
     fn: () => regionBoundariesDeckLayer(regionLevel),
+    renderTooltip({ target }: { target: VectorTarget }) {
+      return createElement(RegionHoverDescription, { key: this.id, target, viewLayer: this });
+    },
   };
 }

--- a/frontend/src/config/regions/population-view-layer.ts
+++ b/frontend/src/config/regions/population-view-layer.ts
@@ -1,3 +1,5 @@
+import { createElement } from 'react';
+
 import { VECTOR_COLOR_MAPS } from 'config/color-maps';
 import { colorMap } from 'lib/color-map';
 import { FieldSpec, ViewLayer } from 'lib/data-map/view-layers';
@@ -9,6 +11,7 @@ import { border, fillColor } from 'lib/deck/props/style';
 
 import { RegionLevel } from './metadata';
 import { REGIONS_SOURCE } from './source';
+import { RegionHoverDescription } from './RegionHoverDescription';
 
 export function populationViewLayer(regionLevel: RegionLevel): ViewLayer {
   const source = REGIONS_SOURCE;
@@ -52,6 +55,9 @@ export function populationViewLayer(regionLevel: RegionLevel): ViewLayer {
           highlightColor: [0, 255, 255, 100],
         },
       );
+    },
+    renderTooltip({ target }: { target: VectorTarget }) {
+      return createElement(RegionHoverDescription, { key: this.id, target, viewLayer: this });
     },
   };
 }

--- a/frontend/src/config/solutions/marine-view-layer.ts
+++ b/frontend/src/config/solutions/marine-view-layer.ts
@@ -1,0 +1,63 @@
+import { DataFilterExtension } from '@deck.gl/extensions';
+import { createElement } from 'react';
+
+import { VectorTarget } from "lib/data-map/types";
+import { ViewLayer } from "lib/data-map/view-layers";
+import { selectableMvtLayer } from "lib/deck/layers/selectable-mvt-layer";
+import { dataColorMap } from 'lib/deck/props/color-map';
+import { fillColor } from 'lib/deck/props/style';
+
+import { SolutionHoverDescription } from "./SolutionHoverDescription";
+
+function filterRange(value: boolean) {
+  return value ? [1, 1] : [0, 1];
+}
+
+export function marineViewLayer({ dataFn, colorFn, filters}): ViewLayer {
+  return {
+    id: 'marine',
+    group: null,
+    interactionGroup: 'solutions',
+    fn: ({ deckProps, selection }) => {
+      const target = selection?.target as VectorTarget;
+      const selectedFeatureId = target?.feature.id;
+      return selectableMvtLayer(
+        {
+          selectionOptions: {
+            selectedFeatureId,
+            polygonOffset: -3000,
+          },
+        },
+        deckProps,
+        {
+          data: '/vector/data/natural_marine_combined.json',
+          binary: false,
+          filled: true,
+          stroked: true,
+
+          getLineColor: [250, 250, 250],
+          getLineWidth: 2,
+          lineWidthUnit: 'meters',
+        },
+        {
+          getFilterValue: ({ properties }) => [
+            parseInt(properties.within_coral_500m ?? '0'),
+            parseInt(properties.within_seagrass_500m ?? '0'),
+            parseInt(properties.within_mangrove_500m ?? '0'),
+          ],
+          filterRange: [
+            filterRange(filters.location_filters.within_coral_500m),
+            filterRange(filters.location_filters.within_seagrass_500m),
+            filterRange(filters.location_filters.within_mangrove_500m),
+          ],
+
+          extensions: [new DataFilterExtension({ filterSize: 3 })],
+        },
+        fillColor(dataColorMap(dataFn, colorFn)),
+      );
+    },
+    renderTooltip({ target }: { target: VectorTarget }) {
+      return createElement(SolutionHoverDescription, { key: this.id, target, viewLayer: this });
+    },
+  };
+}

--- a/frontend/src/config/solutions/terrestrial-view-layer.ts
+++ b/frontend/src/config/solutions/terrestrial-view-layer.ts
@@ -1,0 +1,135 @@
+import { DataFilterExtension } from '@deck.gl/extensions';
+import { createElement } from 'react';
+
+import { VectorTarget } from 'lib/data-map/types';
+import { ViewLayer } from 'lib/data-map/view-layers';
+import { selectableMvtLayer } from 'lib/deck/layers/selectable-mvt-layer';
+import { border, fillColor } from 'lib/deck/props/style';
+import { dataColorMap } from 'lib/deck/props/color-map';
+import { TerrestrialFilters } from 'state/solutions/terrestrial-filters';
+
+import { getSolutionsDataAccessor } from './data-access';
+import { getTerrestrialDataFormats } from './data-formats';
+import { LandUseOption, TerrestrialLocationFilterType } from './domains';
+import { SolutionHoverDescription } from './SolutionHoverDescription';
+
+function landuseFilterValue(p, landuseFilters: Set<LandUseOption>) {
+  return landuseFilters.has(p.landuse_desc) ? 1 : 0;
+}
+
+function locationFilterValue(p, locationFiltersKeys: TerrestrialLocationFilterType[]) {
+  //eslint-disable-next-line eqeqeq -- values are currently sometimes 1 and sometimes true
+  return locationFiltersKeys.every((key) => p[key] == true) ? 1 : 0;
+}
+
+function terrestrialFilters(
+  filters: TerrestrialFilters,
+  landuseFilterSet: Set<LandUseOption>,
+  locationFilterKeys: TerrestrialLocationFilterType[],
+  doFilter: boolean = true,
+) {
+  return {
+    getFilterValue: ({ properties }) => [
+      doFilter ? landuseFilterValue(properties, landuseFilterSet) : 1,
+      doFilter ? properties.slope_degrees : 1,
+      doFilter ? properties.elevation_m : 1,
+      doFilter ? locationFilterValue(properties, locationFilterKeys) : 1,
+    ],
+    filterRange: [
+      [1, 1],
+      doFilter ? [...filters.slope_degrees] : [1, 1],
+      doFilter ? [...filters.elevation_m] : [1, 1],
+      [1, 1],
+    ],
+
+    updateTriggers: {
+      getFilterValue: [doFilter, landuseFilterSet, locationFilterKeys],
+    },
+
+    extensions: [new DataFilterExtension({ filterSize: 4 })],
+  };
+}
+
+export function terrestrialViewLayer({
+  fieldSpec,
+  colorSpec,
+  dataFn,
+  colorFn,
+  filters,
+  landuseFilterSet,
+  locationFilterKeys,
+}): ViewLayer {
+  return {
+    id: 'terrestrial',
+    group: null,
+    interactionGroup: 'solutions',
+    styleParams: colorSpec && {
+      colorMap: {
+        fieldSpec,
+        colorSpec,
+      },
+    },
+    dataAccessFn: getSolutionsDataAccessor,
+    dataFormatsFn: getTerrestrialDataFormats,
+    fn: ({ deckProps, zoom, selection }) => {
+      const switchoverZoom = 14.5;
+      const target = selection?.target as VectorTarget;
+      const selectedFeatureId = target?.feature.id;
+
+      return [
+        selectableMvtLayer(
+          {
+            selectionOptions: {
+              selectedFeatureId,
+              polygonOffset: -1000,
+            },
+          },
+          deckProps,
+          {
+            id: `${deckProps.id}@points`,
+            data: '/vector/data/natural_terrestrial_combined_points.json',
+            visible: zoom < switchoverZoom,
+            binary: false,
+            filled: true,
+            pointAntialiasing: false,
+            stroked: false,
+          },
+          {
+            getPointRadius: 35,
+            pointRadiusUnit: 'meters',
+            pointRadiusMinPixels: 4,
+            pointRadiusMaxPixels: 7,
+          },
+          fillColor(dataColorMap(dataFn, colorFn)),
+          terrestrialFilters(filters, landuseFilterSet, locationFilterKeys, zoom < switchoverZoom),
+        ),
+        selectableMvtLayer(
+          {
+            selectionOptions: {
+              selectedFeatureId,
+              polygonOffset: -1000,
+            },
+          },
+          deckProps,
+          {
+            data: '/vector/data/natural_terrestrial_combined.json',
+            minZoom: 14,
+            visible: zoom >= switchoverZoom,
+            binary: false,
+            filled: true,
+
+            getLineWidth: 1,
+            lineWidthUnit: 'pixels',
+            lineWidthMinPixels: 1,
+          },
+          border(),
+          fillColor(dataColorMap(dataFn, colorFn)),
+          terrestrialFilters(filters, landuseFilterSet, locationFilterKeys, zoom >= switchoverZoom),
+        ),
+      ];
+    },
+    renderTooltip({ target }: { target: VectorTarget }) {
+      return createElement(SolutionHoverDescription, { key: this.id, target, viewLayer: this });
+    },
+  };
+}

--- a/frontend/src/map/tooltip/TooltipContent.tsx
+++ b/frontend/src/map/tooltip/TooltipContent.tsx
@@ -13,25 +13,6 @@ const TooltipSection = ({ children }) => (
   </Box>
 );
 
-function renderTooltip({
-  key,
-  target,
-  viewLayer,
-  Component,
-}: {
-  key?: string;
-  target: VectorTarget | RasterTarget;
-  viewLayer: ViewLayer;
-  Component: FC<HoverDescription>;
-}) {
-  // renderTooltip isn't implemented on all view layers yet.
-  if (viewLayer.renderTooltip) {
-    return viewLayer.renderTooltip({ target });
-  }
-  // Fallback to the default tooltip component for older layers.
-  return <Component key={key} target={target} viewLayer={viewLayer} />;
-}
-
 export const TooltipContent: FC = () => {
   const layerStates = useRecoilValue(layerHoverStates);
   const layerStateEntries = [...layerStates.entries()];
@@ -45,13 +26,13 @@ export const TooltipContent: FC = () => {
       <Box minWidth={200}>
         <ErrorBoundary message="There was a problem displaying the tooltip.">
           {layerStateEntries.map(([type, layerState]) => {
-            const { isHovered, hoverTarget, Component } = layerState;
+            const { isHovered, hoverTarget } = layerState;
             if (isHovered) {
               if (Array.isArray(hoverTarget)) {
                 return (
                   <TooltipSection key={type}>
                     {hoverTarget.map(({ target, viewLayer }) =>
-                      renderTooltip({ key: viewLayer.id, target, viewLayer, Component }),
+                      viewLayer.renderTooltip({ target }),
                     )}
                   </TooltipSection>
                 );
@@ -59,7 +40,7 @@ export const TooltipContent: FC = () => {
               const { target, viewLayer } = hoverTarget;
               return (
                 <TooltipSection key={type}>
-                  {renderTooltip({ target, viewLayer, Component })}
+                  {viewLayer.renderTooltip({ target })}
                 </TooltipSection>
               );
             }

--- a/frontend/src/state/interactions/interaction-state.ts
+++ b/frontend/src/state/interactions/interaction-state.ts
@@ -20,19 +20,17 @@ const interactionGroupEntries = [...INTERACTION_GROUPS.entries()];
 type LayerHoverState = {
   isHovered: boolean;
   hoverTarget: IT;
-  Component: FC<RasterHoverDescription> | FC<VectorHoverDescription>;
 };
 
 export const layerHoverStates = selector({
   key: 'layerHoverStates',
   get: ({ get }) => {
     const regionDataShown = get(showPopulationState);
-    const mapEntries = interactionGroupEntries.map(([groupId, group]) => {
+    const mapEntries = interactionGroupEntries.map(([groupId]) => {
       const hoverTarget = get(hoverState(groupId));
-      const Component = group.Component;
       const isHovered =
         groupId === 'regions' ? regionDataShown && hasHover(hoverTarget) : hasHover(hoverTarget);
-      return [groupId, { isHovered, hoverTarget, Component }] as [string, LayerHoverState];
+      return [groupId, { isHovered, hoverTarget }] as [string, LayerHoverState];
     });
     return new Map<string, LayerHoverState>(mapEntries);
   },

--- a/frontend/src/state/layers/modules/drought.ts
+++ b/frontend/src/state/layers/modules/drought.ts
@@ -1,22 +1,13 @@
-import { ASSETS_SOURCE } from 'config/assets/source';
 import { VECTOR_COLOR_MAPS } from 'config/color-maps';
-import { getDroughtDataAccessor } from 'config/drought/data-access';
-import {
-  getDroughtOptionsDataFormats,
-  getDroughtRiskDataFormats,
-} from 'config/drought/data-formats';
+import { droughtOptionsViewLayer } from 'config/drought/drought-options-view-layer';
+import { droughtRiskViewLayer } from 'config/drought/drought-risk-view-layer';
 import {
   DroughtOptionsVariableType,
   DroughtRiskVariableType,
   DROUGHT_OPTIONS_VARIABLES_WITH_RCP,
   DROUGHT_RISK_VARIABLES_WITH_RCP,
 } from 'config/drought/metadata';
-import { colorMap } from 'lib/color-map';
-import { VectorTarget } from 'lib/data-map/types';
 import { ColorSpec, FieldSpec, ViewLayer } from 'lib/data-map/view-layers';
-import { selectableMvtLayer } from 'lib/deck/layers/selectable-mvt-layer';
-import { dataColorMap } from 'lib/deck/props/color-map';
-import { border, fillColor, pointRadius } from 'lib/deck/props/style';
 import { selector } from 'recoil';
 import {
   droughtOptionsVariableState,
@@ -72,42 +63,7 @@ export const droughtRegionsLayerState = selector<ViewLayer>({
     const fieldSpec = get(droughtRegionsFieldSpecState);
     const colorSpec = get(droughtRegionsColorSpecState);
 
-    const dataFn = getDroughtDataAccessor(fieldSpec);
-    const colorFn = colorMap(colorSpec);
-
-    return {
-      id: 'drought_risk',
-      group: null,
-      interactionGroup: 'drought',
-      dataAccessFn: getDroughtDataAccessor,
-      dataFormatsFn: getDroughtRiskDataFormats,
-      styleParams: {
-        colorMap: {
-          fieldSpec,
-          colorSpec,
-        },
-      },
-
-      fn: ({ deckProps, selection }) => {
-        const target = selection?.target as VectorTarget;
-        const selectedFeatureId = target?.feature.id;
-        return selectableMvtLayer(
-          {
-            selectionOptions: {
-              selectedFeatureId,
-            },
-          },
-          deckProps,
-          {
-            data: ASSETS_SOURCE.getDataUrl({ assetId: 'drought_combined' }),
-
-            filled: true,
-          },
-          border([255, 255, 255]),
-          fillColor(dataColorMap(dataFn, colorFn)),
-        );
-      },
-    };
+    return droughtRiskViewLayer({ fieldSpec, colorSpec });
   },
 });
 
@@ -157,41 +113,6 @@ export const droughtOptionsLayerState = selector<ViewLayer>({
     const fieldSpec = get(droughtOptionsFieldSpecState);
     const colorSpec = get(droughtOptionsColorSpecState);
 
-    const dataFn = getDroughtDataAccessor(fieldSpec);
-    const colorFn = colorMap(colorSpec);
-
-    return {
-      id: 'drought_options',
-      group: null,
-      interactionGroup: 'drought',
-      dataAccessFn: getDroughtDataAccessor,
-      dataFormatsFn: getDroughtOptionsDataFormats,
-      styleParams: {
-        colorMap: {
-          fieldSpec,
-          colorSpec,
-        },
-      },
-      fn: ({ deckProps, selection, zoom }) => {
-        const target = selection?.target as VectorTarget;
-        const selectedFeatureId = target?.feature.id;
-        selectableMvtLayer(
-          {
-            selectionOptions: {
-              selectedFeatureId,
-            },
-          },
-          deckProps,
-          {
-            data: ASSETS_SOURCE.getDataUrl({ assetId: 'drought_options' }),
-
-            filled: true,
-          },
-          pointRadius(zoom),
-          border([255, 255, 255]),
-          fillColor(dataColorMap(dataFn, colorFn)),
-        );
-      },
-    };
+    return droughtOptionsViewLayer({ fieldSpec, colorSpec });
   },
 });

--- a/frontend/src/state/layers/modules/marine.ts
+++ b/frontend/src/state/layers/modules/marine.ts
@@ -1,15 +1,11 @@
-import { DataFilterExtension } from '@deck.gl/extensions';
 import { MARINE_HABITAT_COLORS } from 'config/solutions/colors';
+import { marineViewLayer } from 'config/solutions/marine-view-layer';
 import { ViewLayer, FieldSpec } from 'lib/data-map/view-layers';
-import { VectorTarget } from 'lib/data-map/types';
 import { selector } from 'recoil';
 import { sectionStyleValueState, sectionVisibilityState } from 'state/sections';
 import { featureProperty } from 'lib/deck/props/data-source';
-import { dataColorMap } from 'lib/deck/props/color-map';
-import { fillColor } from 'lib/deck/props/style';
 import { Accessor } from 'lib/deck/props/getters';
 import { marineFiltersState } from 'state/solutions/marine-filters';
-import { selectableMvtLayer } from 'lib/deck/layers/selectable-mvt-layer';
 
 export function habitatColorMap(x: string) {
   return MARINE_HABITAT_COLORS[x]?.css ?? MARINE_HABITAT_COLORS['other'].css;
@@ -44,10 +40,6 @@ export const marineFieldSpecState = selector<FieldSpec>({
   },
 });
 
-function filterRange(value: boolean) {
-  return value ? [1, 1] : [0, 1];
-}
-
 export const marineLayerState = selector<ViewLayer>({
   key: 'marineLayerState',
   get: ({ get }) => {
@@ -67,48 +59,6 @@ export const marineLayerState = selector<ViewLayer>({
       return null;
     }
 
-    return {
-      id: 'marine',
-      group: null,
-      interactionGroup: 'solutions',
-      fn: ({ deckProps, selection }) => {
-        const target = selection?.target as VectorTarget;
-        const selectedFeatureId = target?.feature.id;
-        return selectableMvtLayer(
-          {
-            selectionOptions: {
-              selectedFeatureId,
-              polygonOffset: -3000,
-            },
-          },
-          deckProps,
-          {
-            data: '/vector/data/natural_marine_combined.json',
-            binary: false,
-            filled: true,
-            stroked: true,
-
-            getLineColor: [250, 250, 250],
-            getLineWidth: 2,
-            lineWidthUnit: 'meters',
-          },
-          {
-            getFilterValue: ({ properties }) => [
-              parseInt(properties.within_coral_500m ?? '0'),
-              parseInt(properties.within_seagrass_500m ?? '0'),
-              parseInt(properties.within_mangrove_500m ?? '0'),
-            ],
-            filterRange: [
-              filterRange(filters.location_filters.within_coral_500m),
-              filterRange(filters.location_filters.within_seagrass_500m),
-              filterRange(filters.location_filters.within_mangrove_500m),
-            ],
-
-            extensions: [new DataFilterExtension({ filterSize: 3 })],
-          },
-          fillColor(dataColorMap(dataFn, colorFn)),
-        );
-      },
-    };
+    return marineViewLayer({ dataFn, colorFn, filters });
   },
 });

--- a/frontend/src/state/layers/modules/terrestrial.ts
+++ b/frontend/src/state/layers/modules/terrestrial.ts
@@ -1,25 +1,18 @@
-import { DataFilterExtension } from '@deck.gl/extensions';
 import { TERRESTRIAL_LANDUSE_COLORS } from 'config/solutions/colors';
+import { terrestrialViewLayer } from 'config/solutions/terrestrial-view-layer';
 import { ViewLayer, FieldSpec, ColorSpec } from 'lib/data-map/view-layers';
 import { selector } from 'recoil';
 import { sectionStyleValueState, sectionVisibilityState } from 'state/sections';
 import {
-  TerrestrialFilters,
   terrestrialFiltersState,
   TerrestrialLocationFilters,
 } from 'state/solutions/terrestrial-filters';
 import { colorMap } from 'lib/color-map';
 import { VECTOR_COLOR_MAPS } from 'config/color-maps';
-import { VectorTarget } from 'lib/data-map/types';
 import { featureProperty } from 'lib/deck/props/data-source';
-import { dataColorMap } from 'lib/deck/props/color-map';
-import { border, fillColor } from 'lib/deck/props/style';
 import { Accessor } from 'lib/deck/props/getters';
 import { LandUseOption, TerrestrialLocationFilterType } from 'config/solutions/domains';
 import { truthyKeys } from 'lib/helpers';
-import { selectableMvtLayer } from 'lib/deck/layers/selectable-mvt-layer';
-import { getTerrestrialDataFormats } from 'config/solutions/data-formats';
-import { getSolutionsDataAccessor } from 'config/solutions/data-access';
 import { landuseFilterState } from 'state/solutions/landuse-tree';
 
 export function landuseColorMap(x: string) {
@@ -81,15 +74,6 @@ export const terrestrialFieldSpecState = selector<FieldSpec>({
   },
 });
 
-function landuseFilterValue(p, landuseFilters: Set<LandUseOption>) {
-  return landuseFilters.has(p.landuse_desc) ? 1 : 0;
-}
-
-function locationFilterValue(p, locationFiltersKeys: TerrestrialLocationFilterType[]) {
-  //eslint-disable-next-line eqeqeq -- values are currently sometimes 1 and sometimes true
-  return locationFiltersKeys.every((key) => p[key] == true) ? 1 : 0;
-}
-
 const landuseFilterSetState = selector<Set<LandUseOption>>({
   key: 'landuseFilterSetState',
   get: ({ get }) => new Set(truthyKeys(get(landuseFilterState))),
@@ -104,34 +88,6 @@ const locationFilterKeysState = selector<TerrestrialLocationFilterType[]>({
   key: 'locationFilterKeysState',
   get: ({ get }) => truthyKeys(get(locationFilterState)),
 });
-
-function terrestrialFilters(
-  filters: TerrestrialFilters,
-  landuseFilterSet: Set<LandUseOption>,
-  locationFilterKeys: TerrestrialLocationFilterType[],
-  doFilter: boolean = true,
-) {
-  return {
-    getFilterValue: ({ properties }) => [
-      doFilter ? landuseFilterValue(properties, landuseFilterSet) : 1,
-      doFilter ? properties.slope_degrees : 1,
-      doFilter ? properties.elevation_m : 1,
-      doFilter ? locationFilterValue(properties, locationFilterKeys) : 1,
-    ],
-    filterRange: [
-      [1, 1],
-      doFilter ? [...filters.slope_degrees] : [1, 1],
-      doFilter ? [...filters.elevation_m] : [1, 1],
-      [1, 1],
-    ],
-
-    updateTriggers: {
-      getFilterValue: [doFilter, landuseFilterSet, locationFilterKeys],
-    },
-
-    extensions: [new DataFilterExtension({ filterSize: 4 })],
-  };
-}
 
 export const terrestrialLayerState = selector<ViewLayer>({
   key: 'terrestrialLayerState',
@@ -157,85 +113,14 @@ export const terrestrialLayerState = selector<ViewLayer>({
     const landuseFilterSet = get(landuseFilterSetState);
     const locationFilterKeys = get(locationFilterKeysState);
 
-    return {
-      id: 'terrestrial',
-      group: null,
-      interactionGroup: 'solutions',
-      styleParams: colorSpec && {
-        colorMap: {
-          fieldSpec,
-          colorSpec,
-        },
-      },
-      dataAccessFn: getSolutionsDataAccessor,
-      dataFormatsFn: getTerrestrialDataFormats,
-      fn: ({ deckProps, zoom, selection }) => {
-        const switchoverZoom = 14.5;
-        const target = selection?.target as VectorTarget;
-        const selectedFeatureId = target?.feature.id;
-
-        return [
-          selectableMvtLayer(
-            {
-              selectionOptions: {
-                selectedFeatureId,
-                polygonOffset: -1000,
-              },
-            },
-            deckProps,
-            {
-              id: `${deckProps.id}@points`,
-              data: '/vector/data/natural_terrestrial_combined_points.json',
-              visible: zoom < switchoverZoom,
-              binary: false,
-              filled: true,
-              pointAntialiasing: false,
-              stroked: false,
-            },
-            {
-              getPointRadius: 35,
-              pointRadiusUnit: 'meters',
-              pointRadiusMinPixels: 4,
-              pointRadiusMaxPixels: 7,
-            },
-            fillColor(dataColorMap(dataFn, colorFn)),
-            terrestrialFilters(
-              filters,
-              landuseFilterSet,
-              locationFilterKeys,
-              zoom < switchoverZoom,
-            ),
-          ),
-          selectableMvtLayer(
-            {
-              selectionOptions: {
-                selectedFeatureId,
-                polygonOffset: -1000,
-              },
-            },
-            deckProps,
-            {
-              data: '/vector/data/natural_terrestrial_combined.json',
-              minZoom: 14,
-              visible: zoom >= switchoverZoom,
-              binary: false,
-              filled: true,
-
-              getLineWidth: 1,
-              lineWidthUnit: 'pixels',
-              lineWidthMinPixels: 1,
-            },
-            border(),
-            fillColor(dataColorMap(dataFn, colorFn)),
-            terrestrialFilters(
-              filters,
-              landuseFilterSet,
-              locationFilterKeys,
-              zoom >= switchoverZoom,
-            ),
-          ),
-        ];
-      },
-    };
+    return terrestrialViewLayer({
+      fieldSpec,
+      colorSpec,
+      dataFn,
+      colorFn,
+      filters,
+      landuseFilterSet,
+      locationFilterKeys,
+    });
   },
 });

--- a/frontend/src/state/layers/view-layers.ts
+++ b/frontend/src/state/layers/view-layers.ts
@@ -14,20 +14,18 @@ import { networksLayerState } from './modules/networks';
 import { regionsLayerState } from './modules/regions';
 import { terrestrialLayerState } from './modules/terrestrial';
 
-const layerDisplayOrder = [
-  regionsLayerState,
-  droughtRegionsLayerState,
-  terrestrialLayerState,
-  marineLayerState,
-  hazardsLayerState,
-  buildingsLayerState,
-  networksLayerState,
-  droughtOptionsLayerState,
-  featureBoundingBoxLayerState,
-  labelsLayerState,
-];
-
 export const viewLayersState = selector<ConfigTree<ViewLayer>>({
   key: 'viewLayersState',
-  get: ({ get }) => get(waitForAll(layerDisplayOrder)),
+  get: ({ get }) => get(waitForAll([
+    regionsLayerState,
+    droughtRegionsLayerState,
+    terrestrialLayerState,
+    marineLayerState,
+    hazardsLayerState,
+    buildingsLayerState,
+    networksLayerState,
+    droughtOptionsLayerState,
+    featureBoundingBoxLayerState,
+    labelsLayerState,
+  ])),
 });


### PR DESCRIPTION
- move view layer definitions from `src/state` to `src/config`.
- use `viewLayer.renderTooltip` to show tooltips for interactive layers.
- remove the redundant `Component` property from vector layers.