### PR TITLE
build(frontend): add a canary build workflow

### DIFF
--- a/.github/workflows/canary-frontend.yml
+++ b/.github/workflows/canary-frontend.yml
@@ -1,0 +1,37 @@
+name: Create and publish canary Docker image to GHCR
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: "{{defaultContext}}:frontend"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          tags: |
+            ghcr.io/nismod/jsrat-frontend:${{ github.ref_name }}
+            ghcr.io/nismod/jsrat-frontend:canary
+          secrets: |
+            GH_TOKEN=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Build a canary image on pushes to main, or manually from feature branches. This might be useful for testing unreleased features in a staging environment.