### PR TITLE
refactor(frontend): asset layer style params

### DIFF
--- a/frontend/src/config/assets/asset-view-layer.ts
+++ b/frontend/src/config/assets/asset-view-layer.ts
@@ -37,7 +37,8 @@ export function assetViewLayer(
     params: {
       assetId,
     },
-    fn: ({ deckProps, zoom, styleParams, selection }: ViewLayerFunctionOptions) => {
+    fn({ deckProps, zoom, selection }: ViewLayerFunctionOptions) {
+      const styleParams = this?.styleParams;
       const target = selection?.target as VectorTarget;
       const selectedFeatureId = target?.feature.id;
       return selectableMvtLayer(
@@ -59,7 +60,8 @@ export function assetViewLayer(
     },
     dataAccessFn: customDataAccessFn,
     dataFormatsFn: getAssetDataFormats,
-    renderLegend({ colorMap }) {
+    renderLegend() {
+      const { colorMap } = this.styleParams;
       const key = `${colorMap.fieldSpec.fieldGroup}-${colorMap.fieldSpec.field}`;
       const legendFormatConfig = this.dataFormatsFn(colorMap.fieldSpec);
       return createElement(VectorLegend, { key, colorMap, legendFormatConfig });

--- a/frontend/src/config/networks/network-view-layer.ts
+++ b/frontend/src/config/networks/network-view-layer.ts
@@ -1,0 +1,9 @@
+import { ViewLayer } from 'lib/data-map/view-layers';
+import { INFRASTRUCTURE_VIEW_LAYERS } from './view-layers';
+
+export function networkViewLayer({ network, styleParams }): ViewLayer {
+  return {
+    ...INFRASTRUCTURE_VIEW_LAYERS[network],
+    styleParams,
+  };
+}

--- a/frontend/src/lib/data-map/view-layers.ts
+++ b/frontend/src/lib/data-map/view-layers.ts
@@ -46,9 +46,6 @@ export interface FormatConfig<D = unknown> {
 export type ViewLayerDataAccessFunction = (fieldSpec: FieldSpec) => Accessor<string>;
 export type ViewLayerDataFormatFunction = (fieldSpec: FieldSpec) => FormatConfig;
 
-interface LegendProps {
-  colorMap?: ColorMap;
-}
 export interface ViewLayer {
   id: string;
   params?: any;
@@ -60,7 +57,7 @@ export interface ViewLayer {
   legendDataFormatsFn?: ViewLayerDataFormatFunction;
   spatialType?: string;
   interactionGroup?: string;
-  renderLegend?: (legendProps: LegendProps) => JSX.Element;
+  renderLegend?: () => JSX.Element;
   renderTooltip?: ({ target }: { target: RasterTarget | VectorTarget }) => JSX.Element;
 }
 

--- a/frontend/src/map/legend/MapLegend.tsx
+++ b/frontend/src/map/legend/MapLegend.tsx
@@ -3,13 +3,11 @@ import { FC } from 'react';
 import { ViewLayer } from 'lib/data-map/view-layers';
 import { useRecoilValue } from 'recoil';
 import { viewLayersFlatState } from 'state/layers/view-layers-flat';
-import { viewLayersParamsState } from 'state/layers/view-layers-params';
 import { Stack, Box, Paper, Divider } from '@mui/material';
 import { MobileTabContentWatcher } from 'pages/map/layouts/mobile/tab-has-content';
 
 export const MapLegend: FC = () => {
   const viewLayers = useRecoilValue(viewLayersFlatState);
-  const viewLayersParams = useRecoilValue(viewLayersParamsState);
 
   const rasterViewLayers = [];
 
@@ -20,13 +18,10 @@ export const MapLegend: FC = () => {
       rasterViewLayers.push(viewLayer);
     } else {
       /**
-       * get style params from the viewLayerParams mechanism
-       * (old mechanism for styleParams used by asset layers),
-       * or the style params set directly in the new layer
-       * (new mechanism used for styleParams by NBS, drought, population etc)
+       * get style params from the style params set directly in the new layer
+       * (new mechanism used for styleParams by assets, NBS, drought, population etc)
        */
-      const { colorMap } =
-        viewLayersParams[viewLayer.id].styleParams ?? viewLayer.styleParams ?? {};
+      const { colorMap } = viewLayer.styleParams ?? {};
 
       if (colorMap) {
         /**
@@ -44,18 +39,14 @@ export const MapLegend: FC = () => {
       }
     }
   });
+  const layersToShow = [...rasterViewLayers, ...Object.values(dataColorMaps)];
 
   return rasterViewLayers.length || Object.keys(dataColorMaps).length ? (
     <Paper>
       <MobileTabContentWatcher tabId="legend" />
       <Box p={1} maxWidth={270}>
         <Stack gap={0.3} divider={<Divider />}>
-          {rasterViewLayers.map((viewLayer) => viewLayer.renderLegend())}
-          {Object.values(dataColorMaps).map((viewLayer) => {
-            const { colorMap } =
-              viewLayer.styleParams ?? viewLayersParams[viewLayer.id].styleParams ?? {};
-            return viewLayer.renderLegend({ colorMap });
-          })}
+          {layersToShow.map((viewLayer) => viewLayer.renderLegend())}
         </Stack>
       </Box>
     </Paper>

--- a/frontend/src/state/layers/modules/networks.ts
+++ b/frontend/src/state/layers/modules/networks.ts
@@ -1,6 +1,5 @@
 import * as networkColorMaps from 'config/networks/color-maps';
 import { AdaptationOptionParams } from 'config/domains/adaptation';
-import { INFRASTRUCTURE_VIEW_LAYERS } from 'config/networks/view-layers';
 import { ViewLayer, StyleParams, ColorSpec, FieldSpec } from 'lib/data-map/view-layers';
 import { StateEffect } from 'lib/recoil/state-effects/types';
 import { atom, selector } from 'recoil';
@@ -20,12 +19,18 @@ import fromPairs from 'lodash/fromPairs';
 import mapValues from 'lodash/mapValues';
 import { recalculateCheckboxStates } from 'lib/controls/checkbox-tree/CheckboxTree';
 import { LayerSpec } from 'asset-list/use-sorted-features';
+import { networkViewLayer } from 'config/networks/network-view-layer';
 
 export const networksLayerState = selector<ViewLayer[]>({
   key: 'networkLayersState',
   get: ({ get }) =>
     get(sectionVisibilityState('assets'))
-      ? get(networkSelectionState).map((network) => INFRASTRUCTURE_VIEW_LAYERS[network])
+      ? get(networkSelectionState).map((network) => {
+          return networkViewLayer({
+            network,
+            styleParams: get(networkStyleParamsState),
+          });
+        })
       : [],
 });
 

--- a/frontend/src/state/layers/view-layers-params.ts
+++ b/frontend/src/state/layers/view-layers-params.ts
@@ -1,11 +1,10 @@
 import { atomFamily, selector, selectorFamily, useRecoilTransaction_UNSTABLE } from 'recoil';
 
-import { StyleParams, ViewLayer, ViewLayerParams } from 'lib/data-map/view-layers';
+import { ViewLayer, ViewLayerParams } from 'lib/data-map/view-layers';
 
 import { viewLayersFlatState } from './view-layers-flat';
 import _ from 'lodash';
 import { selectionState } from 'lib/state/interactions/interaction-state';
-import { networkStyleParamsState } from './modules/networks';
 
 export const viewLayerState = atomFamily<ViewLayer, string>({
   key: 'viewLayerState',
@@ -29,7 +28,6 @@ export const singleViewLayerParamsState = selectorFamily<ViewLayerParams, string
 
       const layerParams: {
         selection?: ViewLayerParams['selection'];
-        styleParams?: StyleParams;
       } = {};
 
       if (viewLayer == null) return layerParams;
@@ -38,10 +36,6 @@ export const singleViewLayerParamsState = selectorFamily<ViewLayerParams, string
       const groupSelection = get(selectionState(interactionGroup));
 
       layerParams.selection = groupSelection?.viewLayer.id === viewLayer.id ? groupSelection : null;
-
-      if (viewLayer?.group === 'networks') {
-        layerParams.styleParams = get(networkStyleParamsState);
-      }
 
       return layerParams;
     },


### PR DESCRIPTION
Add the new `viewLayer.styleParams` to asset layers, replacing the old `viewLayerParams[layer.id].styleParams`.