### PR TITLE
refactor(frontend): remove global config/colors

### DIFF
--- a/frontend/src/config/view-layers/buildings/buildings-view-layer.ts
+++ b/frontend/src/config/view-layers/buildings/buildings-view-layer.ts
@@ -1,5 +1,5 @@
 import { ViewLayer } from 'lib/data-map/view-layers';
-import { COLORS } from 'config/colors';
+import { COLORS } from './colors';
 import { assetViewLayer } from 'config/view-layers/assets/asset-view-layer';
 import { border, fillColor } from 'lib/deck/props/style';
 import { assetDataAccessFunction } from 'config/view-layers/assets/data-access';

--- a/frontend/src/config/view-layers/buildings/colors.ts
+++ b/frontend/src/config/view-layers/buildings/colors.ts
@@ -1,0 +1,13 @@
+import { makeColorConfig } from 'lib/helpers';
+
+export const COLORS = makeColorConfig({
+  buildings_commercial: '#f2808c',
+  buildings_industrial: '#cb97f4',
+  buildings_institutional: '#808cf2',
+  buildings_mixed: '#f09e69',
+  buildings_other: '#bfb4c2',
+  buildings_recreation: '#95e78b',
+  buildings_residential: '#f2e680',
+  buildings_resort: '#f9b2ea',
+  buildings_unknown: '#dfe4de',
+});

--- a/frontend/src/config/view-layers/networks/colors.ts
+++ b/frontend/src/config/view-layers/networks/colors.ts
@@ -44,6 +44,4 @@ export const COLORS = makeColorConfig({
   buildings_residential: '#f2e680',
   buildings_resort: '#f9b2ea',
   buildings_unknown: '#dfe4de',
-
-  regions_no_data: '#ccc',
 });

--- a/frontend/src/config/view-layers/networks/metadata.ts
+++ b/frontend/src/config/view-layers/networks/metadata.ts
@@ -1,4 +1,4 @@
-import { COLORS } from 'config/colors';
+import { COLORS } from './colors';
 import { makeConfig } from 'lib/helpers';
 
 /* Line widths:

--- a/frontend/src/config/view-layers/networks/view-layers.ts
+++ b/frontend/src/config/view-layers/networks/view-layers.ts
@@ -8,7 +8,7 @@ import {
   pointRadius,
 } from 'lib/deck/props/style';
 
-import { COLORS } from 'config/colors';
+import { COLORS } from './colors';
 import { infrastructureViewLayer } from './infrastructure-view-layer';
 import { StyleParams, ViewLayer } from 'lib/data-map/view-layers';
 import { fillColor, strokeColor } from 'lib/deck/props/style';


### PR DESCRIPTION
Move colour config down to individual view layers eg. `config/view-layers/buildings/colors`.