### PR TITLE
refactor(frontend): raster colour map config

### DIFF
--- a/frontend/src/config/view-layers/hazards/HazardHoverDescription.tsx
+++ b/frontend/src/config/view-layers/hazards/HazardHoverDescription.tsx
@@ -3,7 +3,8 @@ import { FC } from 'react';
 import { RasterHoverDescription } from 'lib/data-map/types';
 import { RasterHoverDescription as RasterTooltip } from 'map/tooltip/content/RasterHoverDescription';
 
-import { HAZARDS_METADATA, HAZARD_COLOR_MAPS } from './metadata';
+import * as HAZARD_COLOR_MAPS from './color-maps';
+import { HAZARDS_METADATA } from './metadata';
 
 export const HazardHoverDescription: FC<RasterHoverDescription> = ({ target, viewLayer }) => {
   const { label, dataUnit } = HAZARDS_METADATA[viewLayer.id];

--- a/frontend/src/config/view-layers/hazards/HazardLegend.tsx
+++ b/frontend/src/config/view-layers/hazards/HazardLegend.tsx
@@ -3,7 +3,8 @@ import { FC } from 'react';
 import { RasterLegend } from 'map/legend/RasterLegend';
 import { ViewLayer } from 'lib/data-map/view-layers';
 
-import { HAZARD_COLOR_MAPS, HAZARDS_METADATA } from './metadata';
+import * as HAZARD_COLOR_MAPS from './color-maps';
+import { HAZARDS_METADATA } from './metadata';
 
 export const HazardLegend: FC<{ viewLayer: ViewLayer }> = ({ viewLayer }) => {
   const { id } = viewLayer;

--- a/frontend/src/config/view-layers/hazards/color-maps.ts
+++ b/frontend/src/config/view-layers/hazards/color-maps.ts
@@ -1,0 +1,19 @@
+export const fluvial = {
+  scheme: 'blues',
+  range: [0, 10],
+};
+
+export const coastal = {
+  scheme: 'greens',
+  range: [0, 10],
+};
+
+export const surface = {
+  scheme: 'purples',
+  range: [0, 10],
+};
+
+export const cyclone = {
+  scheme: 'reds',
+  range: [0, 75],
+};

--- a/frontend/src/config/view-layers/hazards/hazard-view-layer.ts
+++ b/frontend/src/config/view-layers/hazards/hazard-view-layer.ts
@@ -8,7 +8,7 @@ import { RasterTarget } from 'lib/data-map/types';
 
 import { HazardLegend } from './HazardLegend';
 import { HazardHoverDescription } from './HazardHoverDescription';
-import { HAZARD_COLOR_MAPS } from './metadata';
+import * as HAZARD_COLOR_MAPS from './color-maps';
 import { HAZARD_SOURCE } from './source';
 
 export function getHazardId<

--- a/frontend/src/config/view-layers/hazards/metadata.ts
+++ b/frontend/src/config/view-layers/hazards/metadata.ts
@@ -17,24 +17,5 @@ export const HAZARDS_METADATA = {
   },
 };
 
-export const HAZARD_COLOR_MAPS = {
-  fluvial: {
-    scheme: 'blues',
-    range: [0, 10],
-  },
-  coastal: {
-    scheme: 'greens',
-    range: [0, 10],
-  },
-  surface: {
-    scheme: 'purples',
-    range: [0, 10],
-  },
-  cyclone: {
-    scheme: 'reds',
-    range: [0, 75],
-  },
-};
-
 export const HAZARDS_MAP_ORDER = ['cyclone', 'fluvial', 'surface', 'coastal'];
 export const HAZARDS_UI_ORDER = ['fluvial', 'surface', 'coastal', 'cyclone'];


### PR DESCRIPTION
Configure raster colour maps as `config/hazards/color-maps`, for consistency with other layer configs.