### PR TITLE
refactor(frontend): expand/collapse sidebar with visibility toggle

### DIFF
--- a/frontend/src/sidebar/VisibilityToggle.tsx
+++ b/frontend/src/sidebar/VisibilityToggle.tsx
@@ -1,19 +1,20 @@
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
 import { useRecoilState } from 'recoil';
-import { sectionVisibilityState } from 'state/sections';
+import { sectionVisibilityState, sidebarSectionExpandedState } from 'state/sections';
 
 export const VisibilityToggle = ({ id }) => {
   const [visibility, setVisibility] = useRecoilState(sectionVisibilityState(id));
+  const [expanded, setExpanded] = useRecoilState(sidebarSectionExpandedState(id));
+
+  function handleClick(e) {
+    setVisibility(!visibility);
+    setExpanded(!visibility);
+    e.stopPropagation();
+  }
 
   return (
-    <IconButton
-      title={visibility ? 'Hide layer' : 'Show layer'}
-      onClick={(e) => {
-        setVisibility((visibility) => !visibility);
-        e.stopPropagation();
-      }}
-    >
+    <IconButton title={visibility ? 'Hide layer' : 'Show layer'} onClick={handleClick}>
       {visibility ? <Visibility /> : <VisibilityOff />}
     </IconButton>
   );


### PR DESCRIPTION
Wire up the visibility toggles in the sidebar so that they expand/collapse the current section.