### PR TITLE
test(frontend): add details selection state to stories

### DIFF
--- a/frontend/src/details/features/FeatureSidebar.stories.tsx
+++ b/frontend/src/details/features/FeatureSidebar.stories.tsx
@@ -1,13 +1,47 @@
 import { StoryObj, Meta } from '@storybook/react';
 import { http, HttpResponse, delay } from 'msw';
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
 
-import { FeatureSidebarContent } from './FeatureSidebarContent';
+import { selectionState } from 'lib/state/interactions/interaction-state';
 import mockFeature from 'mocks/details/features/mockFeature.json';
 import mockFeatureDetails from 'mocks/details/features/mockFeatureDetails.json';
+import { FeatureSidebar } from './FeatureSidebar';
+
+function fixedWidthDecorator(Story) {
+  return (
+    <div style={{ width: '45ch' }}>
+      <Story />
+    </div>
+  );
+}
+
+function dataLoaderDecorator(Story, { args }) {
+  const [, setFeatureSelection] = useRecoilState(selectionState('assets'));
+  const mockSelection = {
+    interactionGroup: 'assets',
+    interactionStyle: 'vector',
+    target: {
+      feature: args.feature,
+    },
+    viewLayer: {
+      id: args.id,
+      group: 'networks',
+      fn: () => {},
+    },
+  };
+
+  useEffect(() => {
+    setFeatureSelection(mockSelection);
+  }, []);
+
+  return <Story />;
+}
 
 const meta = {
-  title: 'Details/FeatureSidebarContent',
-  component: FeatureSidebarContent,
+  title: 'Details/FeatureSidebar',
+  component: FeatureSidebar,
+  decorators: [fixedWidthDecorator, dataLoaderDecorator],
 } as Meta;
 
 export default meta;
@@ -17,8 +51,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     feature: mockFeature,
-    assetType: 'road_edges_class_b',
-    showRiskSection: true,
+    id: 'road_edges_class_b',
   },
   parameters: {
     msw: {

--- a/frontend/src/details/features/FeatureSidebar.tsx
+++ b/frontend/src/details/features/FeatureSidebar.tsx
@@ -12,6 +12,7 @@ import { InteractionTarget, VectorTarget } from 'lib/data-map/types';
 
 export const FeatureSidebar: FC = () => {
   const featureSelection = useRecoilValue(selectionState('assets'));
+  console.log('featureSelection:', featureSelection);
 
   if (!featureSelection) return null;
 

--- a/frontend/src/details/regions/RegionDetailsContent.stories.tsx
+++ b/frontend/src/details/regions/RegionDetailsContent.stories.tsx
@@ -1,11 +1,31 @@
 import { StoryObj, Meta } from '@storybook/react';
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
 
+import { selectionState } from 'lib/state/interactions/interaction-state';
 import mockRegion from 'mocks/details/regions/mockRegion.json';
-import { RegionDetailsContent } from './RegionDetailsContent';
+import { RegionDetails } from './RegionDetails';
 
+function fixedWidthDecorator(Story) {
+  return (
+    <div style={{ width: '300px' }}>
+      <Story />
+    </div>
+  );
+}
+
+function dataLoaderDecorator(Story, { args }) {
+  const [, setRegionSelection] = useRecoilState(selectionState('regions'));
+  useEffect(() => {
+    setRegionSelection(args.region);
+  }, []);
+
+  return <Story />;
+}
 const meta = {
-  title: 'Details/RegionDetailsContent',
-  component: RegionDetailsContent,
+  title: 'Details/RegionDetails',
+  component: RegionDetails,
+  decorators: [fixedWidthDecorator, dataLoaderDecorator],
 } as Meta;
 
 export default meta;
@@ -14,6 +34,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    selectedRegion: mockRegion,
+    region: mockRegion,
   },
 };

--- a/frontend/src/details/solutions/SolutionsSidebar.stories.tsx
+++ b/frontend/src/details/solutions/SolutionsSidebar.stories.tsx
@@ -1,12 +1,45 @@
 import { StoryObj, Meta } from '@storybook/react';
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
 
+import { selectionState } from 'lib/state/interactions/interaction-state';
 import mockTerrestrialFeature from 'mocks/details/solutions/mockTerrestrialFeature.json';
 import mockMarineFeature from 'mocks/details/solutions/mockMarineFeature.json';
-import { SolutionsSidebarContent } from './SolutionsSidebarContent';
+import { SolutionsSidebar } from './SolutionsSidebar';
+
+function fixedWidthDecorator(Story) {
+  return (
+    <div style={{ width: '300px' }}>
+      <Story />
+    </div>
+  );
+}
+
+function dataLoaderDecorator(Story, { args }) {
+  const [, setFeatureSelection] = useRecoilState(selectionState('solutions'));
+  const mockSelection = {
+    interactionGroup: 'solutions',
+    interactionStyle: 'vector',
+    target: {
+      feature: args.feature,
+    },
+    viewLayer: {
+      id: args.id,
+      group: null,
+      fn: () => {},
+    },
+  };
+  useEffect(() => {
+    setFeatureSelection(mockSelection);
+  }, []);
+
+  return <Story />;
+}
 
 const meta = {
-  title: 'Details/SolutionsSidebarContent',
-  component: SolutionsSidebarContent,
+  title: 'Details/SolutionsSidebar',
+  component: SolutionsSidebar,
+  decorators: [fixedWidthDecorator, dataLoaderDecorator],
 } as Meta;
 
 export default meta;
@@ -15,15 +48,13 @@ type Story = StoryObj<typeof meta>;
 export const Terrestrial: Story = {
   args: {
     feature: mockTerrestrialFeature,
-    solutionType: 'terrestrial',
-    showRiskSection: true,
+    id: 'terrestrial',
   },
 };
 
 export const Marine: Story = {
   args: {
     feature: mockMarineFeature,
-    solutionType: 'marine',
-    showRiskSection: true,
+    id: 'marine',
   },
 };


### PR DESCRIPTION
Add Recoil state to the Details sidebar stories, to simulate map feature selection in the app.