### PR TITLE
refactor(frontend): shorten URLs for tree data

### DIFF
--- a/frontend/src/data-layers/networks/sidebar/hierarchy.ts
+++ b/frontend/src/data-layers/networks/sidebar/hierarchy.ts
@@ -2,6 +2,7 @@ import { TreeNode } from 'lib/controls/checkbox-tree/tree-node';
 
 interface NetworkLayerData {
   label: string;
+  url?: string;
 }
 
 export const NETWORK_LAYERS_HIERARCHY: TreeNode<NetworkLayerData>[] = [
@@ -16,18 +17,22 @@ export const NETWORK_LAYERS_HIERARCHY: TreeNode<NetworkLayerData>[] = [
           {
             id: 'elec_edges_high',
             label: 'High Voltage',
+            url: '01',
           },
           {
             id: 'elec_edges_low',
             label: 'Low Voltage',
+            url: '02',
           },
           {
             id: 'elec_nodes_pole',
             label: 'Poles',
+            url: '03',
           },
           {
             id: 'elec_nodes_substation',
             label: 'Substations',
+            url: '04',
           },
         ],
       },
@@ -38,28 +43,34 @@ export const NETWORK_LAYERS_HIERARCHY: TreeNode<NetworkLayerData>[] = [
           {
             id: 'elec_nodes_diesel',
             label: 'Diesel',
+            url: '05',
           },
           {
             id: 'elec_nodes_gas',
             label: 'Gas',
+            url: '06',
           },
           {
             id: 'elec_nodes_hydro',
             label: 'Hydro',
+            url: '07',
           },
           {
             id: 'elec_nodes_solar',
             label: 'Solar',
+            url: '08',
           },
           {
             id: 'elec_nodes_wind',
             label: 'Wind',
+            url: '09',
           },
         ],
       },
       {
         id: 'elec_nodes_demand',
         label: 'Demand',
+        url: '0a',
       },
     ],
   },
@@ -74,14 +85,17 @@ export const NETWORK_LAYERS_HIERARCHY: TreeNode<NetworkLayerData>[] = [
           {
             id: 'rail_edges',
             label: 'Railways',
+            url: '0b',
           },
           {
             id: 'rail_stations',
             label: 'Stations',
+            url: '0c',
           },
           {
             id: 'rail_junctions',
             label: 'Junctions',
+            url: '0d',
           },
         ],
       },
@@ -96,32 +110,39 @@ export const NETWORK_LAYERS_HIERARCHY: TreeNode<NetworkLayerData>[] = [
               {
                 id: 'road_edges_class_a',
                 label: 'Class A',
+                url: '0e',
               },
               {
                 id: 'road_edges_class_b',
                 label: 'Class B',
+                url: '0f',
               },
               {
                 id: 'road_edges_class_c',
                 label: 'Class C',
+                url: '10',
               },
               {
                 id: 'road_edges_metro',
                 label: 'Metro',
+                url: '11',
               },
               {
                 id: 'road_edges_track',
                 label: 'Track',
+                url: '12',
               },
               {
                 id: 'road_edges_other',
                 label: 'Other',
+                url: '13',
               },
             ],
           },
           {
             id: 'road_bridges',
             label: 'Bridges',
+            url: '14',
           },
         ],
       },
@@ -132,18 +153,22 @@ export const NETWORK_LAYERS_HIERARCHY: TreeNode<NetworkLayerData>[] = [
           {
             id: 'port_areas_break',
             label: 'Break',
+            url: '15',
           },
           {
             id: 'port_areas_container',
             label: 'Container',
+            url: '16',
           },
           {
             id: 'port_areas_industry',
             label: 'Industry',
+            url: '17',
           },
           {
             id: 'port_areas_silo',
             label: 'Silo',
+            url: '18',
           },
         ],
       },
@@ -154,10 +179,12 @@ export const NETWORK_LAYERS_HIERARCHY: TreeNode<NetworkLayerData>[] = [
           {
             id: 'airport_runways',
             label: 'Runways',
+            url: '19',
           },
           {
             id: 'airport_terminals',
             label: 'Terminals',
+            url: '1a',
           },
         ],
       },
@@ -174,6 +201,7 @@ export const NETWORK_LAYERS_HIERARCHY: TreeNode<NetworkLayerData>[] = [
           {
             id: 'water_potable_edges',
             label: 'Supply Pipelines',
+            url: '1b',
           },
           {
             id: 'water_potable_nodes',
@@ -182,58 +210,72 @@ export const NETWORK_LAYERS_HIERARCHY: TreeNode<NetworkLayerData>[] = [
               {
                 id: 'water_potable_nodes_booster',
                 label: 'Booster Station',
+                url: '1c',
               },
               {
                 id: 'water_potable_nodes_catchment',
                 label: 'Catchment',
+                url: '1d',
               },
               {
                 id: 'water_potable_nodes_entombment',
                 label: 'Entombment',
+                url: '1e',
               },
               {
                 id: 'water_potable_nodes_filter',
                 label: 'Filter Plant',
+                url: '1f',
               },
               {
                 id: 'water_potable_nodes_intake',
                 label: 'Intake',
+                url: '20',
               },
               {
                 id: 'water_potable_nodes_well',
                 label: 'Production Well',
+                url: '21',
               },
               {
                 id: 'water_potable_nodes_pump',
                 label: 'Pump Station',
+                url: '22',
               },
               {
                 id: 'water_potable_nodes_relift',
                 label: 'Relift Station',
+                url: '23',
               },
               {
                 id: 'water_potable_nodes_reservoir',
                 label: 'Reservoir',
+                url: '24',
               },
               {
                 id: 'water_potable_nodes_river_source',
                 label: 'River Source',
+                url: '25',
               },
               {
                 id: 'water_potable_nodes_spring',
                 label: 'Spring',
+                url: '26',
               },
               {
                 id: 'water_potable_nodes_tank',
                 label: 'Storage Tank',
+                url: '27',
               },
               {
                 id: 'water_potable_nodes_sump',
                 label: 'Sump',
+                url: '28',
               },
               {
                 id: 'water_potable_nodes_tp',
                 label: 'Treatment Plant',
+                url: '29',
               },
             ],
           },
@@ -246,10 +288,12 @@ export const NETWORK_LAYERS_HIERARCHY: TreeNode<NetworkLayerData>[] = [
           {
             id: 'water_irrigation_edges',
             label: 'Irrigation Canals',
+            url: '2a',
           },
           {
             id: 'water_irrigation_nodes',
             label: 'Irrigation Wells',
+            url: '2b',
           },
         ],
       },
@@ -264,10 +308,12 @@ export const NETWORK_LAYERS_HIERARCHY: TreeNode<NetworkLayerData>[] = [
               {
                 id: 'water_waste_sewer_gravity',
                 label: 'Gravity',
+                url: '2c',
               },
               {
                 id: 'water_waste_sewer_pressure',
                 label: 'Pressure',
+                url: '2d',
               },
             ],
           },
@@ -278,18 +324,22 @@ export const NETWORK_LAYERS_HIERARCHY: TreeNode<NetworkLayerData>[] = [
               {
                 id: 'water_waste_nodes_sump',
                 label: 'Sump',
+                url: '2e',
               },
               {
                 id: 'water_waste_nodes_pump',
                 label: 'Pump',
+                url: '2f',
               },
               {
                 id: 'water_waste_nodes_relift',
                 label: 'Relift Station',
+                url: '30',
               },
               {
                 id: 'water_waste_nodes_wwtp',
                 label: 'Treatment Plant',
+                url: '31',
               },
             ],
           },

--- a/frontend/src/data-layers/terrestrial/sidebar/landuse-hierarchy.ts
+++ b/frontend/src/data-layers/terrestrial/sidebar/landuse-hierarchy.ts
@@ -3,6 +3,7 @@ import { TreeNode } from 'lib/controls/checkbox-tree/tree-node';
 interface LanduseTypeData {
   id: string;
   label: string;
+  url?: string;
 }
 
 export const LANDUSE_HIERARCHY: TreeNode<LanduseTypeData>[] = [
@@ -10,26 +11,28 @@ export const LANDUSE_HIERARCHY: TreeNode<LanduseTypeData>[] = [
     id: 'agriculture',
     label: 'Agriculture',
     children: [
-      { id: 'Fields: Bare Land', label: 'Fields: Bare Land' },
+      { id: 'Fields: Bare Land', label: 'Fields: Bare Land', url: '01' },
       {
         id: 'Fields: Herbaceous crops, fallow, cultivated vegetables',
         label: 'Fields: Herbaceous crops, fallow, cultivated vegetables',
+        url: '02',
       },
       {
         id: 'Fields: Pasture,Human disturbed, grassland',
         label: 'Fields: Pasture, human-disturbed, grassland',
+        url: '03',
       },
     ],
   },
-  { id: 'Bare Rock', label: 'Bare Rock' },
+  { id: 'Bare Rock', label: 'Bare Rock', url: '04' },
   {
     id: 'bamboo',
     label: 'Bamboo and Mixed',
     children: [
-      { id: 'Bamboo', label: 'Bamboo' },
-      { id: 'Bamboo and Fields', label: 'Bamboo and Fields' },
-      { id: 'Bamboo and Secondary Forest', label: 'Bamboo and Secondary Forest' },
-      { id: 'Fields  and Bamboo', label: 'Fields and Bamboo' },
+      { id: 'Bamboo', label: 'Bamboo', url: '05' },
+      { id: 'Bamboo and Fields', label: 'Bamboo and Fields', url: '06' },
+      { id: 'Bamboo and Secondary Forest', label: 'Bamboo and Secondary Forest', url: '07' },
+      { id: 'Fields  and Bamboo', label: 'Fields and Bamboo', url: '08' },
     ],
   },
   { id: 'Buildings and other infrastructures', label: 'Built-up areas' },
@@ -40,32 +43,35 @@ export const LANDUSE_HIERARCHY: TreeNode<LanduseTypeData>[] = [
       {
         id: 'Closed broadleaved forest (Primary Forest)',
         label: 'Closed broadleaved forest (Primary Forest)',
+        url: '09',
       },
       {
         id: 'Disturbed broadleaved forest (Secondary Forest)',
         label: 'Disturbed broadleaved forest (Secondary Forest)',
+        url: '0a',
       },
-      { id: 'Secondary Forest', label: 'Secondary Forest' },
-      { id: 'Swamp Forest', label: 'Swamp Forest' },
-      { id: 'Mangrove Forest', label: 'Mangrove Forest' },
+      { id: 'Secondary Forest', label: 'Secondary Forest', url: '0b' },
+      { id: 'Swamp Forest', label: 'Swamp Forest', url: '0c' },
+      { id: 'Mangrove Forest', label: 'Mangrove Forest', url: '0d' },
     ],
   },
   {
     id: 'mining',
     label: 'Mining',
     children: [
-      { id: 'Bauxite Extraction', label: 'Bauxite Extraction' },
-      { id: 'Quarry', label: 'Quarry' },
+      { id: 'Bauxite Extraction', label: 'Bauxite Extraction', url: '0e' },
+      { id: 'Quarry', label: 'Quarry', url: '0f' },
     ],
   },
   {
     id: 'mixed',
     label: 'Mixed Use',
     children: [
-      { id: 'Fields and Secondary Forest', label: 'Fields and Secondary Forest' },
+      { id: 'Fields and Secondary Forest', label: 'Fields and Secondary Forest', url: '10' },
       {
         id: 'Fields or Secondary Forest/Pine Plantation',
         label: 'Fields or Secondary Forest/Pine Plantation',
+        url: '11',
       },
     ],
   },
@@ -73,10 +79,11 @@ export const LANDUSE_HIERARCHY: TreeNode<LanduseTypeData>[] = [
     id: 'open-dry-forest',
     label: 'Open dry forest',
     children: [
-      { id: 'Open dry forest - Short', label: 'Open dry forest - Short' },
+      { id: 'Open dry forest - Short', label: 'Open dry forest - Short', url: '12' },
       {
         id: 'Open dry forest - Tall (Woodland/Savanna)',
         label: 'Open dry forest - Tall (Woodland/Savanna)',
+        url: '13',
       },
     ],
   },
@@ -84,20 +91,21 @@ export const LANDUSE_HIERARCHY: TreeNode<LanduseTypeData>[] = [
     id: 'plantation',
     label: 'Plantation',
     children: [
-      { id: 'Hardwood Plantation: Euculytus', label: 'Hardwood Plantation: Euculytus' },
-      { id: 'Hardwood Plantation: Mahoe', label: 'Hardwood Plantation: Mahoe' },
-      { id: 'Hardwood Plantation: Mahogany', label: 'Hardwood Plantation: Mahogany' },
-      { id: 'Hardwood Plantation: Mixed', label: 'Hardwood Plantation: Mixed' },
+      { id: 'Hardwood Plantation: Euculytus', label: 'Hardwood Plantation: Euculytus', url: '14' },
+      { id: 'Hardwood Plantation: Mahoe', label: 'Hardwood Plantation: Mahoe', url: '15' },
+      { id: 'Hardwood Plantation: Mahogany', label: 'Hardwood Plantation: Mahogany', url: '16' },
+      { id: 'Hardwood Plantation: Mixed', label: 'Hardwood Plantation: Mixed', url: '17' },
       {
         id: 'Plantation: Tree crops, shrub crops, sugar cane, banana',
         label: 'Plantation: Tree crops, shrub crops, sugar cane, banana',
+        url: '18',
       },
     ],
   },
-  { id: 'Water Body', label: 'Water Body' },
+  { id: 'Water Body', label: 'Water Body', url: '19' },
   {
     id: 'wetland',
     label: 'Wetland',
-    children: [{ id: 'Herbaceous Wetland', label: 'Herbaceous Wetland' }],
+    children: [{ id: 'Herbaceous Wetland', label: 'Herbaceous Wetland', url: '1a' }],
   },
 ];

--- a/frontend/src/data-layers/terrestrial/sidebar/landuse-tree.ts
+++ b/frontend/src/data-layers/terrestrial/sidebar/landuse-tree.ts
@@ -17,21 +17,28 @@ export const landuseTreeExpandedState = atom<string[]>({
 });
 
 export const landuseTreeConfig = buildTreeConfig(LANDUSE_HIERARCHY);
+const landuseTreeURLs = mapValues(landuseTreeConfig.nodes, (node) => node.url);
+const landuseTreeIDs = Object.keys(landuseTreeURLs);
 
 function parseTreeFromString(value: string) {
-  const checkedFields = value.split(',').filter(Boolean);
+  const separator = value.includes('.') ? '.' : ',';
+  const checkedFields = value.split(separator).filter(Boolean);
   const checked = {};
-  checkedFields.forEach((id) => {
+  checkedFields.forEach((url) => {
+    const id = landuseTreeIDs.includes(url)
+      ? url // url is a layer ID.
+      : Object.keys(landuseTreeURLs).find((id) => landuseTreeURLs[id] === url); // url is the hex code for a layer.
     checked[id] = true;
   });
   return recalculateCheckboxStates({ checked, indeterminate: {} }, landuseTreeConfig);
 }
 
 function stringifyTree(tree: CheckboxTreeState) {
-  const checked = Object.keys(tree.checked).filter(
+  const checkedLayers = Object.keys(tree.checked).filter(
     (id) => tree.checked[id] && !landuseTreeConfig.nodes[id].children,
   );
-  return checked.join(',');
+  const checked = checkedLayers.map((id) => landuseTreeURLs[id]);
+  return checked.join('.');
 }
 
 export const landuseTreeCheckboxState = atom<CheckboxTreeState>({


### PR DESCRIPTION
Replace asset layer IDs with shorter hex strings in URLs.