### PR TITLE
fix(frontend): sync tree state with url

### DIFF
--- a/frontend/src/data-layers/networks/state/data-selection.ts
+++ b/frontend/src/data-layers/networks/state/data-selection.ts
@@ -40,6 +40,13 @@ function stringifyTree(tree: CheckboxTreeState) {
   return checked.join('.');
 }
 
+function writeTreeToUrl(tree: CheckboxTreeState, param: string) {
+  const urlTree = stringifyTree(tree);
+  const url = new URL(window.location.href);
+  url.searchParams.set(param, urlTree);
+  window.history.replaceState({}, '', url.toString());
+}
+
 export const networkTreeCheckboxState = atom<CheckboxTreeState>({
   key: 'networkTreeSelectionState',
   default: {
@@ -47,6 +54,14 @@ export const networkTreeCheckboxState = atom<CheckboxTreeState>({
     indeterminate: mapValues(networkTreeConfig.nodes, () => false),
   },
   effects: [
+    ({ onSet }) => {
+      onSet((newTree) => {
+        if (newTree instanceof DefaultValue) {
+          return;
+        }
+        writeTreeToUrl(newTree, 'netTree');
+      });
+    },
     urlSyncEffect({
       storeKey: 'url-json',
       itemKey: 'netTree',

--- a/frontend/src/data-layers/terrestrial/sidebar/landuse-tree.ts
+++ b/frontend/src/data-layers/terrestrial/sidebar/landuse-tree.ts
@@ -41,6 +41,13 @@ function stringifyTree(tree: CheckboxTreeState) {
   return checked.join('.');
 }
 
+function writeTreeToUrl(tree: CheckboxTreeState, param: string) {
+  const urlTree = stringifyTree(tree);
+  const url = new URL(window.location.href);
+  url.searchParams.set(param, urlTree);
+  window.history.replaceState({}, '', url.toString());
+}
+
 export const landuseTreeCheckboxState = atom<CheckboxTreeState>({
   key: 'landuseTreeCheckboxState',
   default: {
@@ -48,6 +55,14 @@ export const landuseTreeCheckboxState = atom<CheckboxTreeState>({
     indeterminate: mapValues(landuseTreeConfig.nodes, () => false),
   },
   effects: [
+    ({ onSet }) => {
+      onSet((newTree) => {
+        if (newTree instanceof DefaultValue) {
+          return;
+        }
+        writeTreeToUrl(newTree, 'landTree');
+      });
+    },
     urlSyncEffect({
       storeKey: 'url-json',
       itemKey: 'landTree',


### PR DESCRIPTION
`urlSyncEffect` works in development, but doesn't always run in production when a tree control changes. Add an effect that syncs a tree's state with the URL whenever the tree changes.