### PR TITLE
feat(frontend): persist URL state across map views

### DIFF
--- a/frontend/src/app/Nav.tsx
+++ b/frontend/src/app/Nav.tsx
@@ -53,7 +53,11 @@ function useMapQueryParams() {
   const lat = useRecoilValue(mapLatUrlState).toFixed(5);
   const lon = useRecoilValue(mapLonUrlState).toFixed(5);
   const zoom = useRecoilValue(mapZoomUrlState).toFixed(2);
-  return new URLSearchParams({ lat, lon, zoom });
+  const url = new URL(window.location.href);
+  url.searchParams.set('lat', lat);
+  url.searchParams.set('lon', lon);
+  url.searchParams.set('zoom', zoom);
+  return url.searchParams;
 }
 
 const mapPages = Object.keys(VIEW_SECTIONS).map((view) => `/${view}`);

--- a/frontend/src/app/state/view.ts
+++ b/frontend/src/app/state/view.ts
@@ -35,6 +35,9 @@ function sectionVisibility(section, sectionConfig) {
 function sectionStyle(section, sectionConfig) {
   const searchParams = new URLSearchParams(window.location.search);
   const styleParam = `${section}Style`;
+  if (styleParam === 'assetsStyle') {
+    return sectionConfig.defaultStyle;
+  }
   return searchParams.has(styleParam)
     ? searchParams.get(styleParam).replaceAll('"', '')
     : sectionConfig.defaultStyle;


### PR DESCRIPTION
Persist all map URL parameters, except for `assetsStyle`, across navigations between map views. This should keep layers like buildings and regions fixed, when you move between Exposure and Risk.