### PR TITLE
refactor(frontend): allow for ignored query params in nav links

### DIFF
--- a/frontend/src/app/Nav.tsx
+++ b/frontend/src/app/Nav.tsx
@@ -57,6 +57,12 @@ function useMapQueryParams() {
   url.searchParams.set('lat', lat);
   url.searchParams.set('lon', lon);
   url.searchParams.set('zoom', zoom);
+  // ignore user settings for assetsStyle, marine, and terrestrial parameters.
+  ['assetsStyle', 'marine', 'terrestrial'].forEach((param) => {
+    if (url.searchParams.has(param)) {
+      url.searchParams.delete(param);
+    }
+  });
   return url.searchParams;
 }
 


### PR DESCRIPTION
Some settings, like infrastructure layer style, marine visibility, and terrestrial visibility, should always use view config defaults when we change map views. This adds an array of query params that should be ignored in navigation links.