### PR TITLE
fix(frontend): missing labels for form controls

### DIFF
--- a/frontend/src/app/sidebar/ui/params/EpochControl.tsx
+++ b/frontend/src/app/sidebar/ui/params/EpochControl.tsx
@@ -1,4 +1,7 @@
 import { FormControl, FormLabel, MenuItem, Select } from '@mui/material';
+import uniqueId from 'lodash/uniqueId';
+import { useRef } from 'react';
+
 import { DataParam } from './DataParam';
 
 function epochLabel(value) {
@@ -7,12 +10,15 @@ function epochLabel(value) {
 }
 
 export const EpochControl = ({ group, disabled = false }) => {
+  const labelId = useRef(uniqueId('epoch-'));
+
   return (
     <FormControl fullWidth disabled={disabled}>
-      <FormLabel>Epoch</FormLabel>
+      <FormLabel id={labelId.current}>Epoch</FormLabel>
       <DataParam group={group} id="epoch">
         {({ value, onChange, options }) => (
           <Select
+            labelId={labelId.current}
             variant="standard"
             value={value}
             onChange={(e) => onChange(e.target.value)}

--- a/frontend/src/app/sidebar/ui/params/RCPControl.tsx
+++ b/frontend/src/app/sidebar/ui/params/RCPControl.tsx
@@ -1,4 +1,7 @@
 import { FormControl, FormLabel, MenuItem, Select } from '@mui/material';
+import uniqueId from 'lodash/uniqueId';
+import { useRef } from 'react';
+
 import { DataParam } from './DataParam';
 
 function rcpLabel(value) {
@@ -6,14 +9,16 @@ function rcpLabel(value) {
 }
 
 export const RCPControl = ({ group, disabled = false }) => {
+  const labelId = useRef(uniqueId('rcp-'));
   return (
     <FormControl fullWidth disabled={disabled}>
-      <FormLabel>
+      <FormLabel id={labelId.current}>
         <abbr title="Representative Concentration Pathway (Climate Scenario)">RCP</abbr>
       </FormLabel>
       <DataParam group={group} id="rcp">
         {({ value, onChange, options }) => (
           <Select
+            labelId={labelId.current}
             variant="standard"
             value={value}
             onChange={(e) => onChange(e.target.value)}

--- a/frontend/src/data-layers/networks/sidebar/DamageSourceControl.tsx
+++ b/frontend/src/data-layers/networks/sidebar/DamageSourceControl.tsx
@@ -7,6 +7,8 @@ import {
   RadioGroup,
   Select,
 } from '@mui/material';
+import uniqueId from 'lodash/uniqueId';
+import { useRef } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { StateEffectRoot } from 'lib/recoil/state-effects/StateEffectRoot';
@@ -26,6 +28,7 @@ import { HAZARDS_METADATA, HAZARDS_UI_ORDER } from 'data-layers/hazards/metadata
 export const DamageSourceControl = () => {
   const [damageSource, setDamageSource] = useRecoilState(damageSourceState);
   const [damageType, setDamageType] = useRecoilState(damageTypeState);
+  const htmlId = useRef(uniqueId('damage-source-'));
 
   return (
     <>
@@ -33,8 +36,9 @@ export const DamageSourceControl = () => {
       <LayerStylePanel>
         <InputSection>
           <FormControl fullWidth>
-            <FormLabel>Damage type</FormLabel>
+            <FormLabel id={`${htmlId.current}-damage-type`}>Damage type</FormLabel>
             <Select<string>
+              labelId={`${htmlId.current}-damage-type`}
               variant="standard"
               value={damageType}
               onChange={(e) => setDamageType(e.target.value)}

--- a/frontend/src/lib/controls/ParamDropdown.tsx
+++ b/frontend/src/lib/controls/ParamDropdown.tsx
@@ -1,5 +1,6 @@
 import { FormControl, FormLabel, MenuItem, Select, SelectProps } from '@mui/material';
-import { PropsWithChildren, useCallback } from 'react';
+import uniqueId from 'lodash/uniqueId';
+import { PropsWithChildren, useCallback, useRef } from 'react';
 import { isValueLabel, ValueLabel } from './params/value-label';
 
 interface ParamDropdownProps<V extends string | number = string> {
@@ -19,11 +20,14 @@ export const ParamDropdown = <V extends string | number = string>({
   disabled = false,
   variant = undefined,
 }: PropsWithChildren<ParamDropdownProps<V>>) => {
+  const htmlId = useRef(uniqueId('param-dropdown-'));
+  const labelId = `${htmlId.current}-input-label`;
   const handleChange = useCallback((e) => onChange(e.target.value), [onChange]);
   return (
     <FormControl fullWidth>
-      <FormLabel>{title}</FormLabel>
+      <FormLabel id={labelId}>{title}</FormLabel>
       <Select
+        labelId={labelId}
         value={value}
         onChange={handleChange}
         size="small"


### PR DESCRIPTION
Add IDs to form controls where the control's label isn't explicitly linked to its control, which makes the label invisible to assistive technology.