### PR TITLE
refactor(frontend): hazard toggle sections

### DIFF
--- a/frontend/src/app/sidebar/ui/params/ReturnPeriodControl.tsx
+++ b/frontend/src/app/sidebar/ui/params/ReturnPeriodControl.tsx
@@ -1,14 +1,24 @@
 import { FormControl, FormLabel } from '@mui/material';
+import uniqueId from 'lodash/uniqueId';
+import { useRef } from 'react';
 import { CustomNumberSlider } from 'lib/controls/CustomSlider';
 import { DataParam } from './DataParam';
 
 export const ReturnPeriodControl = ({ group, ...otherProps }) => {
+  const htmlId = useRef(uniqueId('return-period-'));
+  const labelId = `${htmlId.current}-label`;
   return (
     <FormControl fullWidth>
-      <FormLabel>Return Period</FormLabel>
+      <FormLabel id={labelId}>Return Period</FormLabel>
       <DataParam group={group} id="returnPeriod">
         {({ value, onChange, options }) => (
-          <CustomNumberSlider marks={options} value={value} onChange={onChange} {...otherProps} />
+          <CustomNumberSlider
+            aria-labelledby={labelId}
+            marks={options}
+            value={value}
+            onChange={onChange}
+            {...otherProps}
+          />
         )}
       </DataParam>
     </FormControl>

--- a/frontend/src/lib/controls/accordion-toggle/ToggleSection.tsx
+++ b/frontend/src/lib/controls/accordion-toggle/ToggleSection.tsx
@@ -1,10 +1,5 @@
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Checkbox,
-  FormControlLabel,
-} from '@mui/material';
+import { Accordion, AccordionDetails, AccordionSummary } from '@mui/material';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
 import uniqueId from 'lodash/uniqueId';
 import { createContext, FC, ReactNode, useContext, useRef } from 'react';
 import { useRecoilState } from 'recoil';
@@ -20,10 +15,6 @@ export const ToggleSectionGroup: FC<{
   return <ToggleStateContext.Provider value={toggleState}>{children}</ToggleStateContext.Provider>;
 };
 
-function cancelEvent(e) {
-  e.preventDefault();
-  return false;
-}
 interface ToggleSectionProps {
   id: string;
   label: string;
@@ -43,13 +34,13 @@ export const ToggleSection: FC<ToggleSectionProps> = ({
   const htmlId = useRef(uniqueId('toggle-section-'));
 
   return (
-    <Accordion disableGutters disabled={disabled} expanded={show} onChange={handleShow}>
-      <AccordionSummary id={`${htmlId.current}-header`} aria-controls={`${htmlId.current}-details`}>
-        <FormControlLabel
-          control={<Checkbox checked={show} tabIndex={-1} />}
-          label={label}
-          onClick={cancelEvent}
-        />
+    <Accordion disabled={disabled} expanded={show} onChange={handleShow}>
+      <AccordionSummary
+        id={`${htmlId.current}-header`}
+        aria-controls={`${htmlId.current}-details`}
+        expandIcon={show ? <Visibility /> : <VisibilityOff />}
+      >
+        {label}
       </AccordionSummary>
       <AccordionDetails style={{ display: 'block' }}>{children}</AccordionDetails>
     </Accordion>


### PR DESCRIPTION
Refactor hazard toggle sections to remove checkboxes and replace them with icons for visible/hidden state. Fixes an accessibility error since you can't have checkboxes inside a button (clickable elements can't be nested in the DOM.)

Fix missing labels for Return Period sliders.