### PR TITLE
build(dev): Dev proxy for local Docker backend

### DIFF
--- a/frontend/dev-proxy/proxy-table.docker.json
+++ b/frontend/dev-proxy/proxy-table.docker.json
@@ -1,0 +1,23 @@
+{
+  "/raster": {
+    "target": "http://localhost",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/raster": "/raster"
+    }
+  },
+  "/vector": {
+    "target": "http://localhost",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/vector": "/vector"
+    }
+  },
+  "/api": {
+    "target": "http://localhost",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/api": "/api"
+    }
+  }
+}


### PR DESCRIPTION
The local Docker backend runs all the services behind a proxy on localhost. This proxy table routes requests to each service.