### PR TITLE
chore(frontend): 0.4.12

### DIFF
--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -1,7 +1,7 @@
 # Staging environment - as production except for domain
 services:
   frontend:
-    image: ghcr.io/nismod/jsrat-frontend:0.4.11
+    image: ghcr.io/nismod/jsrat-frontend:0.4.12
     platform: linux/amd64
     build: ./frontend
     ports:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irv-jamaica",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irv-jamaica",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "dependencies": {
         "@deck.gl/extensions": "8.9",
         "@emotion/react": "^11.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "irv-jamaica",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
- persist selected asset features in the page URL.
- upgrade Material UI to v6.
- minor and patch updates for other dependencies.