### PR TITLE
fix(frontend): handle numerical query params as strings

### DIFF
--- a/frontend/src/data-layers/networks/state/data-selection.ts
+++ b/frontend/src/data-layers/networks/state/data-selection.ts
@@ -74,7 +74,7 @@ export const networkTreeCheckboxState = atom<CheckboxTreeState>({
         if (value instanceof DefaultValue) {
           return value;
         }
-        return parseTreeFromString(value as string);
+        return parseTreeFromString(`${value}`);
       },
       write: ({ write, reset }, value) => {
         if (value instanceof DefaultValue) {

--- a/frontend/src/data-layers/terrestrial/sidebar/landuse-tree.ts
+++ b/frontend/src/data-layers/terrestrial/sidebar/landuse-tree.ts
@@ -75,7 +75,7 @@ export const landuseTreeCheckboxState = atom<CheckboxTreeState>({
         if (value instanceof DefaultValue) {
           return value;
         }
-        return parseTreeFromString(value as string);
+        return parseTreeFromString(`${value}`);
       },
       write: ({ write, reset }, value) => {
         if (value instanceof DefaultValue) {


### PR DESCRIPTION
Fix a small bug where a URL query param like `netTree=19` would be passed as a number, but the URL handling code expects all query param values to be strings.

This bug can trigger in the Adaptations view, which resets the networks tree so that only one node is selected. Sharing or reloading that URL results in a map that won't render.