### PR TITLE
fix(frontend): usePrevious hook

### DIFF
--- a/frontend/src/lib/hooks/use-previous.ts
+++ b/frontend/src/lib/hooks/use-previous.ts
@@ -4,6 +4,6 @@ export function usePrevious<T>(value: T): T | undefined {
   const ref = useRef<T>();
   useEffect(() => {
     ref.current = value;
-  });
+  }, [value]);
   return ref.current;
 }


### PR DESCRIPTION
The value returned by `usePrevious` should update whenever the incoming value changes.

See the example here: https://github.com/pkpdapp-team/pkpdapp/blob/master/frontend-v2/src/hooks/usePrevious.ts