### PR TITLE
refactor(frontend): view layer state

### DIFF
--- a/frontend/src/app/map/DataMap.tsx
+++ b/frontend/src/app/map/DataMap.tsx
@@ -1,9 +1,9 @@
-import { FC, useEffect } from 'react';
+import { FC } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { interactionGroupsState } from 'app/state/layers/interaction-groups';
 import { viewLayersFlatState } from 'app/state/layers/view-layers-flat';
-import { useSaveViewLayers, viewLayersParamsState } from 'app/state/layers/view-layers-params';
+import { viewLayersParamsState } from 'app/state/layers/view-layers-params';
 
 import { DataMap } from 'lib/data-map/DataMap';
 
@@ -14,15 +14,8 @@ export const DataMapContainer: FC = () => {
   const background = useRecoilValue(backgroundState);
   const showLabels = useRecoilValue(showLabelsState);
   const viewLayers = useRecoilValue(viewLayersFlatState);
-  const saveViewLayers = useSaveViewLayers();
   const { firstLabelId } = useBasemapStyle(background, showLabels);
-
-  useEffect(() => {
-    saveViewLayers(viewLayers);
-  }, [saveViewLayers, viewLayers]);
-
   const viewLayersParams = useRecoilValue(viewLayersParamsState);
-
   const interactionGroups = useRecoilValue(interactionGroupsState);
 
   return (

--- a/frontend/src/app/map/tooltip/content/VectorHoverDescription.tsx
+++ b/frontend/src/app/map/tooltip/content/VectorHoverDescription.tsx
@@ -4,7 +4,7 @@ import { DataItem } from 'details/features/detail-components';
 import { VectorTarget } from 'lib/data-map/types';
 import { FC } from 'react';
 import { useRecoilValue } from 'recoil';
-import { singleViewLayerParamsState } from 'app/state/layers/view-layers-params';
+import { singleViewLayerParamsState } from 'lib/state/layers/view-layers';
 import { DataDescription } from '../DataDescription';
 import { ColorBox } from './ColorBox';
 import { ViewLayer } from 'lib/data-map/view-layers';

--- a/frontend/src/app/state/layers/view-layers-flat.ts
+++ b/frontend/src/app/state/layers/view-layers-flat.ts
@@ -3,9 +3,9 @@ import { selector } from 'recoil';
 import { flattenConfig } from 'lib/nested-config/flatten-config';
 import { ViewLayer } from 'lib/data-map/view-layers';
 
-import { viewLayersState } from './view-layers';
+import { viewLayerConfigs } from './view-layers';
 
 export const viewLayersFlatState = selector<ViewLayer[]>({
   key: 'viewLayersFlatState',
-  get: ({ get }) => flattenConfig(get(viewLayersState)),
+  get: ({ get }) => flattenConfig(get(viewLayerConfigs)),
 });

--- a/frontend/src/app/state/layers/view-layers-params.ts
+++ b/frontend/src/app/state/layers/view-layers-params.ts
@@ -1,45 +1,10 @@
-import { atomFamily, selector, selectorFamily, useRecoilTransaction_UNSTABLE } from 'recoil';
+import _ from 'lodash';
+import { selector } from 'recoil';
 
-import { ViewLayer, ViewLayerParams } from 'lib/data-map/view-layers';
+import { ViewLayerParams } from 'lib/data-map/view-layers';
+import { singleViewLayerParamsState } from 'lib/state/layers/view-layers';
 
 import { viewLayersFlatState } from './view-layers-flat';
-import _ from 'lodash';
-import { selectionState } from 'lib/state/interactions/interaction-state';
-
-export const viewLayerState = atomFamily<ViewLayer, string>({
-  key: 'viewLayerState',
-  default: null,
-});
-
-export const useSaveViewLayers = () => {
-  return useRecoilTransaction_UNSTABLE(
-    ({ set }) =>
-      (viewLayers: ViewLayer[]) =>
-        viewLayers.forEach((viewLayer) => set(viewLayerState(viewLayer.id), viewLayer)),
-  );
-};
-
-export const singleViewLayerParamsState = selectorFamily<ViewLayerParams, string>({
-  key: 'singleViewLayerParamsState',
-  get:
-    (viewLayerId: string) =>
-    ({ get }) => {
-      const viewLayer = get(viewLayerState(viewLayerId));
-
-      const layerParams: {
-        selection?: ViewLayerParams['selection'];
-      } = {};
-
-      if (viewLayer == null) return layerParams;
-
-      const interactionGroup = viewLayer.interactionGroup;
-      const groupSelection = get(selectionState(interactionGroup));
-
-      layerParams.selection = groupSelection?.viewLayer.id === viewLayer.id ? groupSelection : null;
-
-      return layerParams;
-    },
-});
 
 export const viewLayersParamsState = selector<Record<string, ViewLayerParams>>({
   key: 'viewLayersParamsState',

--- a/frontend/src/app/state/layers/view-layers.ts
+++ b/frontend/src/app/state/layers/view-layers.ts
@@ -9,8 +9,8 @@ import { importLayerState } from 'data-layers/state';
 import { featureBoundingBoxLayerState } from './ui/featureBoundingBox';
 import { labelsLayerState } from './ui/labels';
 
-const viewLayerState = selectorFamily<ViewLayer, string>({
-  key: 'viewLayerState',
+const viewLayerConfig = selectorFamily<ViewLayer, string>({
+  key: 'viewLayerConfig',
   get:
     (type) =>
     async ({ get }) => {
@@ -19,12 +19,12 @@ const viewLayerState = selectorFamily<ViewLayer, string>({
     },
 });
 
-export const viewLayersState = selector<ConfigTree<ViewLayer>>({
-  key: 'viewLayersState',
+export const viewLayerConfigs = selector<ConfigTree<ViewLayer>>({
+  key: 'viewLayerConfigs',
   get: ({ get }) => {
     return get(
       waitForAll([
-        ...VIEW_LAYERS.map(viewLayerState),
+        ...VIEW_LAYERS.map(viewLayerConfig),
         featureBoundingBoxLayerState,
         labelsLayerState,
       ]),

--- a/frontend/src/lib/state/layers/view-layers.ts
+++ b/frontend/src/lib/state/layers/view-layers.ts
@@ -1,0 +1,39 @@
+import { atomFamily, selectorFamily, useRecoilTransaction_UNSTABLE } from 'recoil';
+
+import { ViewLayer, ViewLayerParams } from 'lib/data-map/view-layers';
+import { selectionState } from 'lib/state/interactions/interaction-state';
+
+const viewLayerState = atomFamily<ViewLayer, string>({
+  key: 'viewLayerState',
+  default: null,
+});
+
+export const useSaveViewLayers = () => {
+  return useRecoilTransaction_UNSTABLE(
+    ({ set }) =>
+      (viewLayers: ViewLayer[]) =>
+        viewLayers.forEach((viewLayer) => set(viewLayerState(viewLayer.id), viewLayer)),
+  );
+};
+
+export const singleViewLayerParamsState = selectorFamily<ViewLayerParams, string>({
+  key: 'singleViewLayerParamsState',
+  get:
+    (viewLayerId: string) =>
+    ({ get }) => {
+      const viewLayer = get(viewLayerState(viewLayerId));
+
+      const layerParams: {
+        selection?: ViewLayerParams['selection'];
+      } = {};
+
+      if (viewLayer == null) return layerParams;
+
+      const interactionGroup = viewLayer.interactionGroup;
+      const groupSelection = get(selectionState(interactionGroup));
+
+      layerParams.selection = groupSelection?.viewLayer.id === viewLayer.id ? groupSelection : null;
+
+      return layerParams;
+    },
+});


### PR DESCRIPTION
- move shared view layer state into `src/lib/`.
- document the data map functions that generate the deck.gl layers.
- fix a duplicate Recoil key for `viewLayerState`.