### PR TITLE
refactor(frontend): use a Map for view layer params state

### DIFF
--- a/frontend/src/app/state/layers/view-layers-params.ts
+++ b/frontend/src/app/state/layers/view-layers-params.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { selector } from 'recoil';
 
 import { ViewLayerParams } from 'lib/data-map/view-layers';
@@ -6,14 +5,18 @@ import { singleViewLayerParamsState } from 'lib/state/layers/view-layers';
 
 import { viewLayersFlatState } from './view-layers-flat';
 
-export const viewLayersParamsState = selector<Record<string, ViewLayerParams>>({
+/**
+ * View layer selection and style parameters, mapped by view layer ID.
+ */
+export const viewLayersParamsState = selector<Map<string, ViewLayerParams>>({
   key: 'viewLayersParamsState',
   get: ({ get }) => {
     const viewLayers = get(viewLayersFlatState);
+    const viewLayersParams = new Map() as Map<string, ViewLayerParams>;
+    viewLayers.forEach((viewLayer) => {
+      viewLayersParams.set(viewLayer.id, get(singleViewLayerParamsState(viewLayer.id)));
+    });
 
-    return _(viewLayers)
-      .keyBy('id')
-      .mapValues((viewLayer) => get(singleViewLayerParamsState(viewLayer.id)))
-      .value();
+    return viewLayersParams;
   },
 });

--- a/frontend/src/lib/data-map/DataMap.tsx
+++ b/frontend/src/lib/data-map/DataMap.tsx
@@ -25,12 +25,12 @@ function lookupViewForDeck(deckLayerId: string) {
  */
 function buildLayers(
   viewLayers: ViewLayer[],
-  viewLayersParams: Record<string, ViewLayerParams>,
+  viewLayersParams: Map<string, ViewLayerParams>,
   zoom: number,
   beforeId: string | undefined,
 ) {
   return viewLayers.map((viewLayer) => {
-    const viewLayerParams = viewLayersParams[viewLayer.id];
+    const viewLayerParams = viewLayersParams.get(viewLayer.id);
     const deckProps = {
       id: viewLayer.id,
       pickable: !!viewLayer.interactionGroup,
@@ -62,7 +62,7 @@ export const DataMap: FC<{
   firstLabelId: string;
   interactionGroups: Map<string, InteractionGroupConfig>;
   viewLayers: ViewLayer[];
-  viewLayersParams: Record<string, ViewLayerParams>;
+  viewLayersParams: Map<string, ViewLayerParams>;
 }> = ({ firstLabelId, interactionGroups, viewLayers, viewLayersParams }) => {
   const deckRef = useRef<MapboxOverlay>();
   const { current: map } = useMap();


### PR DESCRIPTION
Get and set a view layer's selection and style state with `viewLayerParamsState.get(layerId)` and `viewLayerParamsState.set(layerId, { styleParams, selection })`.