### PR TITLE
fix(frontend): view layer render types

### DIFF
--- a/frontend/src/details/features/FeatureSidebar.stories.tsx
+++ b/frontend/src/details/features/FeatureSidebar.stories.tsx
@@ -20,22 +20,22 @@ function FixedWidthDecorator(Story) {
 
 function DataLoaderDecorator(Story, { args }) {
   const [, setFeatureSelection] = useRecoilState(selectionState('assets'));
-  const mockSelection = {
-    interactionGroup: 'assets',
-    interactionStyle: 'vector',
-    target: {
-      feature: args.feature,
-    },
-    viewLayer: {
-      id: args.id,
-      group: 'networks',
-      fn: () => ({}) as Layer,
-    },
-  };
 
   useEffect(() => {
+    const mockSelection = {
+      interactionGroup: 'assets',
+      interactionStyle: 'vector',
+      target: {
+        feature: args.feature,
+      },
+      viewLayer: {
+        id: args.id,
+        group: 'networks',
+        fn: () => ({}) as Layer,
+      },
+    };
     setFeatureSelection(mockSelection);
-  }, []);
+  }, [setFeatureSelection, args]);
 
   return <Story />;
 }

--- a/frontend/src/details/features/FeatureSidebar.stories.tsx
+++ b/frontend/src/details/features/FeatureSidebar.stories.tsx
@@ -8,6 +8,7 @@ import { selectionState } from 'lib/state/interactions/interaction-state';
 import mockFeature from 'mocks/details/features/mockFeature.json';
 import mockFeatureDetails from 'mocks/details/features/mockFeatureDetails.json';
 import { FeatureSidebar } from './FeatureSidebar';
+import { Layer } from 'deck.gl/typed';
 
 function FixedWidthDecorator(Story) {
   return (
@@ -28,7 +29,7 @@ function DataLoaderDecorator(Story, { args }) {
     viewLayer: {
       id: args.id,
       group: 'networks',
-      fn: () => {},
+      fn: () => ({}) as Layer,
     },
   };
 

--- a/frontend/src/details/solutions/SolutionsSidebar.stories.tsx
+++ b/frontend/src/details/solutions/SolutionsSidebar.stories.tsx
@@ -7,6 +7,7 @@ import { selectionState } from 'lib/state/interactions/interaction-state';
 import mockTerrestrialFeature from 'mocks/details/solutions/mockTerrestrialFeature.json';
 import mockMarineFeature from 'mocks/details/solutions/mockMarineFeature.json';
 import { SolutionsSidebar } from './SolutionsSidebar';
+import { Layer } from 'deck.gl/typed';
 
 function FixedWidthDecorator(Story) {
   return (
@@ -30,7 +31,7 @@ function DataLoaderDecorator(Story, { args }) {
       viewLayer: {
         id: id,
         group: null,
-        fn: () => {},
+        fn: () => ({}) as Layer,
       },
     };
     setFeatureSelection(mockSelection);

--- a/frontend/src/lib/data-map/DataMap.tsx
+++ b/frontend/src/lib/data-map/DataMap.tsx
@@ -28,7 +28,7 @@ function buildLayers(
   viewLayersParams: Map<string, ViewLayerParams>,
   zoom: number,
   beforeId: string | undefined,
-) {
+): LayersList {
   return viewLayers.map((viewLayer) => {
     const viewLayerParams = viewLayersParams.get(viewLayer.id);
     const deckProps = {
@@ -41,7 +41,7 @@ function buildLayers(
       zoom,
       ...viewLayerParams,
     });
-  }) as LayersList;
+  });
 }
 
 /**

--- a/frontend/src/lib/data-map/view-layers.ts
+++ b/frontend/src/lib/data-map/view-layers.ts
@@ -2,6 +2,7 @@ import { ScaleSequential } from 'd3-scale';
 import { DataLoader } from 'lib/data-loader/data-loader';
 import { Accessor } from 'lib/deck/props/getters';
 import { InteractionTarget, VectorTarget, RasterTarget } from './types';
+import { Layer } from 'deck.gl/typed';
 
 export interface FieldSpec {
   fieldGroup: string;
@@ -51,7 +52,7 @@ export interface ViewLayer {
   params?: any;
   styleParams?: StyleParams;
   group: string;
-  fn: (options: ViewLayerFunctionOptions) => unknown;
+  fn: (options: ViewLayerFunctionOptions) => Layer | Layer[];
   dataAccessFn?: ViewLayerDataAccessFunction;
   dataFormatsFn?: ViewLayerDataFormatFunction;
   legendDataFormatsFn?: ViewLayerDataFormatFunction;


### PR DESCRIPTION
Small type fix: `viewLayer.fn`, which runs whenever we update the data map, should return a deck.gl layer, or an array of deck.gl layers.