### PR TITLE
fix(frontend): shared view layer state

### DIFF
--- a/frontend/src/app/map/DataMap.tsx
+++ b/frontend/src/app/map/DataMap.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { interactionGroupsState } from 'app/state/layers/interaction-groups';
@@ -19,9 +19,9 @@ export const DataMapContainer: FC = () => {
   const { firstLabelId } = useBasemapStyle(background, showLabels);
   const interactionGroups = useRecoilValue(interactionGroupsState);
 
-  if (viewLayersFlat.length === 0) {
+  useEffect(() => {
     setViewLayersFlat(flattenConfig(viewLayers));
-  }
+  }, [viewLayers, setViewLayersFlat]);
 
   return <DataMap firstLabelId={firstLabelId} interactionGroups={interactionGroups} />;
 };


### PR DESCRIPTION
Add an effect to update shared view layer state when layer states change. Otherwise, changes to the sidebar won't be rendered on the map.