### PR TITLE
build(frontend): lint frontend builds

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,7 +90,7 @@
   },
   "scripts": {
     "start": "tsc && vite",
-    "build": "tsc && vite build",
+    "build": "tsc && eslint src && vite build",
     "serve": "vite preview",
     "lint": "eslint src",
     "format": "prettier --write ./src",


### PR DESCRIPTION
Run ESLint on frontend builds. This should catch breaking changes to `src/lib` in CI.

Requirements for a passing build now are:
- no TypeScript errors.
- no linting errors (including prohibited imports in `src/lib`.)
- no failing storybook stories.