### PR TITLE
fix(frontend): hazard data params

### DIFF
--- a/frontend/src/data-layers/hazards/sidebar/HazardsSection.tsx
+++ b/frontend/src/data-layers/hazards/sidebar/HazardsSection.tsx
@@ -5,6 +5,7 @@ import { Box } from '@mui/system';
 import { ErrorBoundary } from 'lib/react/ErrorBoundary';
 
 import { HazardsControl } from './HazardsControl';
+import { useSyncConfigState } from 'app/state/data-params';
 
 /**
  * Sidebar controls for the `hazards` layer.
@@ -15,6 +16,7 @@ import { HazardsControl } from './HazardsControl';
  * - RCP (climate scenario.)
  */
 export const HazardsSection: FC = () => {
+  useSyncConfigState();
   return (
     <SidebarPanel id="hazards" title="Hazards">
       <Box p={2}>


### PR DESCRIPTION
The Hazards sidebar component now needs to be connected to shared library state for data parameters (return period, epoch, and RCP.)