### PR TITLE
fix(frontend): adaptation options params state

### DIFF
--- a/frontend/src/data-layers/networks/sidebar/NetworkControl.tsx
+++ b/frontend/src/data-layers/networks/sidebar/NetworkControl.tsx
@@ -17,12 +17,10 @@ import { NETWORK_LAYERS_HIERARCHY } from './hierarchy';
 import { NETWORKS_METADATA } from '../metadata';
 import { showAdaptationsState } from '../state/layer';
 import adaptationSectorLayers from '../adaptation-sector-layers.json';
-import { dataParamState } from 'lib/state/data-params';
 
 export const NetworkControl: FC = () => {
   const [checkboxState, setCheckboxState] = useRecoilState(networkTreeCheckboxState);
   const [expanded, setExpanded] = useRecoilState(networkTreeExpandedState);
-  const dataParams = useRecoilValue(dataParamState({ group: 'adaptation', param: 'sector' }));
   const updateSector = useUpdateDataParam('adaptation', 'sector');
   const updateSubsector = useUpdateDataParam('adaptation', 'subsector');
   const updateAssetType = useUpdateDataParam('adaptation', 'asset_type');
@@ -34,7 +32,7 @@ export const NetworkControl: FC = () => {
     (id) => checkboxState.checked[id] && !networkTreeConfig.nodes[id].children,
   );
   const adaptationLayer = adaptationSectorLayers.find((x) => selectedLayers.includes(x.layer_name));
-  if (dataParams && adaptationLayer) {
+  if (adaptationLayer) {
     const { sector, subsector, asset_type } = adaptationLayer;
     updateSector(sector);
     updateSubsector(subsector);


### PR DESCRIPTION
Remove a couple of lines that prevent the default adaptation sector from being changed.

- fixes #194.