### PR TITLE
fix(frontend): zoom visibility labels in checkbox trees

### DIFF
--- a/frontend/src/app/sidebar/ui/LayerLabel.tsx
+++ b/frontend/src/app/sidebar/ui/LayerLabel.tsx
@@ -2,7 +2,7 @@ import { VisibilityOff } from '@mui/icons-material';
 import { Box, Stack, Typography } from '@mui/material';
 import { ShapeLegend, LegendShapeType } from 'lib/map-shapes/ShapeLegend';
 import { useRecoilValue } from 'recoil';
-import { zoomState } from 'app/state/zoom';
+import { mapViewStateState } from 'app/state/map-view/map-view-state';
 
 export const LayerLabel = ({
   label,
@@ -17,6 +17,7 @@ export const LayerLabel = ({
   minZoom?: number;
   visible: boolean;
 }) => {
+  console.log('LayerLabel', label, type, color, minZoom, visible);
   return (
     <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={1}>
       <Stack direction="row" alignItems="center">
@@ -29,7 +30,9 @@ export const LayerLabel = ({
 };
 
 function ZoomVisibility({ minZoom }: { minZoom: number }) {
-  const currentZoom = useRecoilValue(zoomState);
+  const mapViewState = useRecoilValue(mapViewStateState);
+  const currentZoom = mapViewState.zoom;
+  console.log('ZoomVisibility', minZoom, currentZoom);
 
   return (
     currentZoom < minZoom && (

--- a/frontend/src/app/sidebar/ui/LayerLabel.tsx
+++ b/frontend/src/app/sidebar/ui/LayerLabel.tsx
@@ -17,7 +17,6 @@ export const LayerLabel = ({
   minZoom?: number;
   visible: boolean;
 }) => {
-  console.log('LayerLabel', label, type, color, minZoom, visible);
   return (
     <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={1}>
       <Stack direction="row" alignItems="center">
@@ -32,7 +31,6 @@ export const LayerLabel = ({
 function ZoomVisibility({ minZoom }: { minZoom: number }) {
   const mapViewState = useRecoilValue(mapViewStateState);
   const currentZoom = mapViewState.zoom;
-  console.log('ZoomVisibility', minZoom, currentZoom);
 
   return (
     currentZoom < minZoom && (

--- a/frontend/src/app/state/zoom.ts
+++ b/frontend/src/app/state/zoom.ts
@@ -1,7 +1,0 @@
-import { mapViewConfig } from 'app/config/map-view';
-import { atom } from 'recoil';
-
-export const zoomState = atom({
-  key: 'zoom',
-  default: mapViewConfig.initialViewState.zoom,
-});


### PR DESCRIPTION
Remove `app/state/zoom`, which isn't used anywhere, and link checkbox trees to `mapViewState.zoom`, from the shared data map library.

- fixes #195.


https://github.com/user-attachments/assets/d205d474-d950-493a-a552-cfa5067b375d

