### PR TITLE
refactor(frontend): checkbox tree labels

### DIFF
--- a/frontend/src/data-layers/networks/sidebar/NetworkControl.tsx
+++ b/frontend/src/data-layers/networks/sidebar/NetworkControl.tsx
@@ -40,6 +40,14 @@ function useSyncAdaptationParameters(checkboxState) {
   }
 }
 
+function getLabel(node, checked) {
+  return node.children ? (
+    node.label
+  ) : (
+    <LayerLabel {...NETWORKS_METADATA[node.id]} label={node.label} visible={checked} />
+  );
+}
+
 export const NetworkControl: FC = () => {
   const [checkboxState, setCheckboxState] = useRecoilState(networkTreeCheckboxState);
   const [expanded, setExpanded] = useRecoilState(networkTreeExpandedState);
@@ -61,13 +69,7 @@ export const NetworkControl: FC = () => {
       <CheckboxTree
         nodes={NETWORK_LAYERS_HIERARCHY}
         config={networkTreeConfig}
-        getLabel={(node, checked) =>
-          node.children ? (
-            node.label
-          ) : (
-            <LayerLabel {...NETWORKS_METADATA[node.id]} label={node.label} visible={checked} />
-          )
-        }
+        getLabel={getLabel}
         checkboxState={checkboxState}
         onCheckboxState={setCheckboxState}
         expanded={expanded}

--- a/frontend/src/data-layers/terrestrial/sidebar/TerrestrialLandUseTree.tsx
+++ b/frontend/src/data-layers/terrestrial/sidebar/TerrestrialLandUseTree.tsx
@@ -10,6 +10,19 @@ import {
   landuseTreeExpandedState,
 } from './landuse-tree';
 
+function getLabel(node, checked) {
+  return node.children ? (
+    node.label
+  ) : (
+    <LayerLabel
+      label={node.label}
+      type="polygon"
+      color={TERRESTRIAL_LANDUSE_COLORS[node.id].css}
+      visible={checked}
+    />
+  );
+}
+
 export const TerrestrialLandUseTree = () => {
   const [checkboxState, setCheckboxState] = useRecoilState(landuseTreeCheckboxState);
   const [expanded, setExpanded] = useRecoilState(landuseTreeExpandedState);
@@ -18,18 +31,7 @@ export const TerrestrialLandUseTree = () => {
     <CheckboxTree
       nodes={LANDUSE_HIERARCHY}
       config={landuseTreeConfig}
-      getLabel={(node, checked) =>
-        node.children ? (
-          node.label
-        ) : (
-          <LayerLabel
-            label={node.label}
-            type="polygon"
-            color={TERRESTRIAL_LANDUSE_COLORS[node.id].css}
-            visible={checked}
-          />
-        )
-      }
+      getLabel={getLabel}
       checkboxState={checkboxState}
       onCheckboxState={setCheckboxState}
       expanded={expanded}


### PR DESCRIPTION
Refactor checkbox tree labels to avoid generating new anonymous functions on every render, avoiding memory leaks.