### PR TITLE
fix(frontend): null refs in hover interactions

### DIFF
--- a/frontend/src/lib/data-map/DataMap.tsx
+++ b/frontend/src/lib/data-map/DataMap.tsx
@@ -81,11 +81,11 @@ export const DataMap: FC<{
 
   const layers = buildLayers(viewLayers, viewLayersParams, zoom, firstLabelId);
   const onClickFeature = (info: any) => {
-    onClick?.(info, deckRef.current);
+    deckRef.current && onClick?.(info, deckRef.current);
     saveViewLayers(viewLayers);
   };
   const onHoverFeature = (info: any) => {
-    onHover?.(info, deckRef.current);
+    deckRef.current && onHover?.(info, deckRef.current);
     saveViewLayers(viewLayers);
   };
 


### PR DESCRIPTION
Sometimes, the map hover interaction is invoked before `deckRef.current` has been set. This adds a check for the deckGL deck before invoking the hover and click interactions.