### PR TITLE
style(backend): lint the backend

### DIFF
--- a/backend/backend/app/main.py
+++ b/backend/backend/app/main.py
@@ -1,11 +1,7 @@
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
 
-from backend.db import models
-from backend.db.database import engine
-
 from .routers import attributes, features
-
 
 
 def custom_generate_unique_id(route: APIRoute):

--- a/backend/backend/app/schemas.py
+++ b/backend/backend/app/schemas.py
@@ -69,7 +69,10 @@ class ReturnPeriodDamagesVariables(DataVariables):
     loss_amax: float
 
 
-class ReturnPeriodDamage(ReturnPeriodDamagesDimensions, ReturnPeriodDamagesVariables):
+class ReturnPeriodDamage(
+    ReturnPeriodDamagesDimensions,
+    ReturnPeriodDamagesVariables
+):
     model_config = ConfigDict(from_attributes=True)
 
 

--- a/backend/backend/db/database.py
+++ b/backend/backend/db/database.py
@@ -9,14 +9,14 @@ from sqlalchemy.orm import sessionmaker
 # pass empty connection string to use PG* environment variables
 # (see https://www.postgresql.org/docs/current/libpq-envars.html)
 engine = create_engine("postgresql+psycopg2://", future=True)
-Session = sessionmaker(engine, autoflush=False, autocommit=False)
+SessionLocal = sessionmaker(engine, autoflush=False, autocommit=False)
 
 
 def get_session():
-    with Session() as session:
+    with SessionLocal() as session:
         yield session
 
 
-SessionDep = Annotated[Session, Depends(get_session)]
+SessionDep = Annotated[SessionLocal, Depends(get_session)]
 
 Base = declarative_base()


### PR DESCRIPTION
- fix linter errors.
- rename `Session` to `SessionLocal`, to avoid confusion with the built-in `Session`.