### PR TITLE
refactpr(frontend): shared map zoom state

### DIFF
--- a/frontend/src/app/Nav.tsx
+++ b/frontend/src/app/Nav.tsx
@@ -19,7 +19,7 @@ import { NavLink as RouterNavLink, LinkProps as RouterLinkProps } from 'react-ro
 import { VIEW_SECTIONS } from 'app/config/views';
 import { useIsMobile } from './use-is-mobile';
 import { withProps } from 'lib/react/with-props';
-import { mapLatUrlState, mapLonUrlState, mapZoomUrlState } from 'app/state/map-view/map-url';
+import { mapLatUrlState, mapLonUrlState, mapZoomUrlState } from 'lib/state/map-view/map-url';
 import { globalStyleVariables } from 'app/theme';
 import { useRecoilValue } from 'recoil';
 

--- a/frontend/src/lib/data-map/BaseMap.tsx
+++ b/frontend/src/lib/data-map/BaseMap.tsx
@@ -2,6 +2,9 @@ import { MapViewState } from 'deck.gl/typed';
 import { StyleSpecification } from 'maplibre-gl';
 import { FC, ReactNode } from 'react';
 import { Map } from 'react-map-gl/maplibre';
+import { useRecoilState } from 'recoil';
+
+import { mapViewStateState, useSyncMapUrl } from 'lib/state/map-view/map-view-state';
 
 export interface BaseMapProps {
   children?: ReactNode;
@@ -10,11 +13,7 @@ export interface BaseMapProps {
   viewState: MapViewState;
 }
 
-/**
- * Displays a react-map-gl basemap component.
- * Accepts children such as a DeckGLOverlay, HUD controls etc
- */
-export const BaseMap: FC<BaseMapProps> = ({ children, mapStyle, onMove, viewState }) => {
+const MapGLMap: FC<BaseMapProps> = ({ children, mapStyle, onMove, viewState }) => {
   return (
     <Map
       reuseMaps={true}
@@ -31,5 +30,25 @@ export const BaseMap: FC<BaseMapProps> = ({ children, mapStyle, onMove, viewStat
     >
       {children}
     </Map>
+  );
+};
+
+/**
+ * Displays a react-map-gl basemap component.
+ * Accepts children such as a DeckGLOverlay, HUD controls etc
+ */
+export const BaseMap: FC<{ children?: ReactNode; mapStyle: StyleSpecification }> = ({
+  children,
+  mapStyle,
+}) => {
+  const [viewState, setViewState] = useRecoilState(mapViewStateState);
+  useSyncMapUrl();
+  function handleViewStateChange({ viewState }: { viewState: MapViewState }) {
+    setViewState(viewState);
+  }
+  return (
+    <MapGLMap viewState={viewState} onMove={handleViewStateChange} mapStyle={mapStyle}>
+      {children}
+    </MapGLMap>
   );
 };

--- a/frontend/src/lib/sidebar/ui/LayerLabel.tsx
+++ b/frontend/src/lib/sidebar/ui/LayerLabel.tsx
@@ -3,10 +3,7 @@ import { Box, Stack, Typography } from '@mui/material';
 import { ShapeLegend, LegendShapeType } from 'lib/map-shapes/ShapeLegend';
 import { atom, useRecoilValue } from 'recoil';
 
-export const labelZoomState = atom({
-  key: 'labelZoomState',
-  default: 0,
-});
+import { mapViewStateState } from 'lib/state/map-view/map-view-state';
 
 export const LayerLabel = ({
   label,
@@ -33,7 +30,8 @@ export const LayerLabel = ({
 };
 
 function ZoomVisibility({ minZoom }: { minZoom: number }) {
-  const currentZoom = useRecoilValue(labelZoomState);
+  const mapViewState = useRecoilValue(mapViewStateState);
+  const currentZoom = mapViewState.zoom;
 
   return (
     currentZoom < minZoom && (

--- a/frontend/src/lib/state/map-view/map-url.ts
+++ b/frontend/src/lib/state/map-view/map-url.ts
@@ -2,8 +2,6 @@ import { number } from '@recoiljs/refine';
 import { DefaultValue, atom } from 'recoil';
 import { WriteAtom, urlSyncEffect } from 'recoil-sync';
 
-import { mapViewConfig } from '../../config/map-view';
-
 /**
  * Makes a recoil-sync write function that saves a number with up to `maximumFractionDigits`
  */
@@ -28,7 +26,7 @@ function makeWriteNumber(itemKey: string, maximumFractionDigits: number) {
 
 export const mapZoomUrlState = atom({
   key: 'mapZoomUrl',
-  default: mapViewConfig.initialViewState.zoom,
+  default: -1,
   effects: [
     urlSyncEffect({
       storeKey: 'url-json',
@@ -42,7 +40,7 @@ export const mapZoomUrlState = atom({
 
 export const mapLonUrlState = atom({
   key: 'mapLonUrl',
-  default: mapViewConfig.initialViewState.longitude,
+  default: -1,
   effects: [
     urlSyncEffect({
       storeKey: 'url-json',
@@ -56,7 +54,7 @@ export const mapLonUrlState = atom({
 
 export const mapLatUrlState = atom({
   key: 'mapLatUrl',
-  default: mapViewConfig.initialViewState.latitude,
+  default: -1,
   effects: [
     urlSyncEffect({
       storeKey: 'url-json',

--- a/frontend/src/lib/state/map-view/map-view-state.ts
+++ b/frontend/src/lib/state/map-view/map-view-state.ts
@@ -1,9 +1,6 @@
-import omit from 'lodash/omit';
 import { DefaultValue, atom, selector } from 'recoil';
 
 import { useSyncStateThrottled } from 'lib/recoil/sync-state-throttled';
-
-import { mapViewConfig } from 'app/config/map-view';
 
 import { mapLatUrlState, mapLonUrlState, mapZoomUrlState } from './map-url';
 
@@ -11,16 +8,9 @@ const mapLatState = atom({ key: 'mapLat', default: mapLatUrlState });
 const mapLonState = atom({ key: 'mapLon', default: mapLonUrlState });
 const mapZoomState = atom({ key: 'mapZoom', default: mapZoomUrlState });
 
-const INITIAL_VIEW_STATE = {
-  ...mapViewConfig.initialViewState,
-  ...mapViewConfig.viewLimits,
-};
-
-const INITIAL_NON_COORDS_STATE = omit(INITIAL_VIEW_STATE, ['latitude', 'longitude', 'zoom']);
-
 export const nonCoordsMapViewStateState = atom({
   key: 'nonCoordsMapViewState',
-  default: { ...INITIAL_NON_COORDS_STATE },
+  default: {},
 });
 
 export const mapViewStateState = selector({


### PR DESCRIPTION
Refactor the base map so that map zoom state is handled in `lib/state/map-view`. Initial map state and style is configured in `app/config/map-view` and passed into the base map. `lib/data-map/BaseMap` is now responsible for updating the map when zoom parameters change.