### PR TITLE
refactor(frontend): data loader management

### DIFF
--- a/frontend/src/lib/data-loader/data-loader-manager.ts
+++ b/frontend/src/lib/data-loader/data-loader-manager.ts
@@ -12,13 +12,18 @@ export class DataLoaderManager {
 
   public getDataLoader(layer: string, fieldSpec: FieldSpec) {
     const loaderKey = getLoaderKey(layer, fieldSpec);
-    let loader = this.loaders.get(loaderKey);
-    if (loader == null) {
+    if (!this.loaders.has(loaderKey)) {
       console.log(`Initialising data loader for ${layer} ${stringify(fieldSpec)}`);
-      loader = new DataLoader(this.nextLoaderId.toString(), layer, fieldSpec);
-      this.nextLoaderId += 1;
-      this.loaders.set(loaderKey, loader);
+      return this.registerDataLoader(layer, fieldSpec);
     }
+    return this.loaders.get(loaderKey);
+  }
+
+  public registerDataLoader(layer: string, fieldSpec: FieldSpec) {
+    const loader = new DataLoader(this.nextLoaderId.toString(), layer, fieldSpec);
+    this.nextLoaderId += 1;
+    const loaderKey = getLoaderKey(layer, fieldSpec);
+    this.loaders.set(loaderKey, loader);
     return loader;
   }
 

--- a/frontend/src/lib/data-loader/data-loader.ts
+++ b/frontend/src/lib/data-loader/data-loader.ts
@@ -46,6 +46,10 @@ export class DataLoader<T = any> {
     return data;
   }
 
+  get hasData() {
+    return this.data.size > 0;
+  }
+
   subscribe(callback: DataLoaderSubscriber) {
     this.subscribers ??= [];
     this.subscribers.push(callback);

--- a/frontend/src/lib/deck/layers/data-loader-layer.ts
+++ b/frontend/src/lib/deck/layers/data-loader-layer.ts
@@ -13,7 +13,7 @@ export function dataLoaderLayer(tileProps, { dataLoader }: DataLoaderOptions) {
     tile: { content },
   } = tileProps;
   if (content && dataLoader) {
-    const ids: number[] = content.map((f: MapGeoJSONFeature) => f.id);
+    const ids: number[] = !dataLoader.hasData ? content.map((f: MapGeoJSONFeature) => f.id) : [];
 
     dataLoader.loadDataForIds(ids);
   }


### PR DESCRIPTION
- `DataLoaderManager`: split `getDataLoader` into `getDataLoader` and `registerDataLoader`.
- `DataLoader`: add `hasData` property to check if the loader is empty.
- `DataLoaderLayer`: check if a layer has data before triggering the default behaviour (load data for all feature IDs in a tile.)