### PR TITLE
refactor(frontend): tooltip view layer params

### DIFF
--- a/frontend/src/app/map/tooltip/content/VectorHoverDescription.tsx
+++ b/frontend/src/app/map/tooltip/content/VectorHoverDescription.tsx
@@ -1,28 +1,17 @@
 import { FC } from 'react';
-import { useRecoilValue } from 'recoil';
 
 import { NETWORKS_METADATA } from 'data-layers/networks/metadata';
 
 import { VectorHoverDescription as BaseDescription } from 'lib/map/tooltip/content/VectorHoverDescription';
 
 import { VectorTarget } from 'lib/data-map/types';
-import { singleViewLayerParamsState } from 'lib/state/layers/view-layers';
 import { ViewLayer } from 'lib/data-map/view-layers';
 
 export const VectorHoverDescription: FC<{
   viewLayer: ViewLayer;
   feature: VectorTarget['feature'];
 }> = ({ viewLayer, feature }) => {
-  const layerParams = useRecoilValue(singleViewLayerParamsState(viewLayer.id));
   const { label: title, color = '#ccc' } = NETWORKS_METADATA[viewLayer.params.assetId];
 
-  return (
-    <BaseDescription
-      layerParams={layerParams}
-      title={title}
-      color={color}
-      viewLayer={viewLayer}
-      feature={feature}
-    />
-  );
+  return <BaseDescription title={title} color={color} viewLayer={viewLayer} feature={feature} />;
 };

--- a/frontend/src/lib/map/tooltip/content/VectorHoverDescription.tsx
+++ b/frontend/src/lib/map/tooltip/content/VectorHoverDescription.tsx
@@ -1,26 +1,27 @@
 import { Typography } from '@mui/material';
 import { FC } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import { DataItem } from '../detail-components';
 import { VectorTarget } from 'lib/data-map/types';
 import { DataDescription } from '../DataDescription';
 import { ColorBox } from './ColorBox';
-import { ViewLayer, ViewLayerParams } from 'lib/data-map/view-layers';
+import { ViewLayer } from 'lib/data-map/view-layers';
+import { singleViewLayerParamsState } from 'lib/state/layers/view-layers';
 
 type VectorHoverDescriptionProps = {
   viewLayer: ViewLayer;
   feature: VectorTarget['feature'];
-  layerParams: ViewLayerParams;
   title: string;
   color: string;
 };
 export const VectorHoverDescription: FC<VectorHoverDescriptionProps> = ({
-  layerParams,
   title,
   color = '#ccc',
   viewLayer,
   feature,
 }) => {
+  const layerParams = useRecoilValue(singleViewLayerParamsState(viewLayer.id));
   const { styleParams } = layerParams;
   const { colorMap } = styleParams ?? {};
 


### PR DESCRIPTION
A small fix for tooltips. View layer params can be loaded in from `lib/state/layers`.