### PR TITLE
fix(frontend): remove Suspense from view layer state

### DIFF
--- a/frontend/src/app/state/layers/view-layers.ts
+++ b/frontend/src/app/state/layers/view-layers.ts
@@ -1,4 +1,4 @@
-import { waitForAll, selector, selectorFamily } from 'recoil';
+import { waitForAll, selector, selectorFamily, noWait } from 'recoil';
 
 import { ViewLayer } from 'lib/data-map/view-layers';
 import { ConfigTree } from 'lib/nested-config/config-tree';
@@ -20,13 +20,24 @@ const VIEW_LAYERS = [
   'droughtOptions',
 ] as string[];
 
-const viewLayerConfig = selectorFamily<ViewLayer, string>({
-  key: 'viewLayerConfig',
+const viewLayerConfigQuery = selectorFamily<ViewLayer, string>({
+  key: 'viewLayerConfigQuery',
   get:
     (type) =>
     async ({ get }) => {
       const layer = await importLayerState(type);
       return get(layer);
+    },
+});
+
+const viewLayerConfig = selectorFamily<ViewLayer, string>({
+  key: 'viewLayerConfig',
+  get:
+    (type) =>
+    ({ get }) => {
+      const loadable = get(noWait(viewLayerConfigQuery(type)));
+      const layer = loadable.state === 'hasValue' ? loadable.contents : null;
+      return layer;
     },
 });
 


### PR DESCRIPTION
Fix a small glitch where the map suspends and blinks when loading a new layer. The fix is to use a Loadable while new layer state loads.