### PR TITLE
fix(frontend): write section visibility states to URL

### DIFF
--- a/frontend/src/data-layers/hazards/state/data-selection.ts
+++ b/frontend/src/data-layers/hazards/state/data-selection.ts
@@ -3,13 +3,20 @@ import fromPairs from 'lodash/fromPairs';
 import { atomFamily, RecoilValue } from 'recoil';
 import { urlSyncEffect } from 'recoil-sync';
 
-export const hazardSelectionState = atomFamily({
+export const hazardSelectionState = atomFamily<boolean, string>({
   key: 'hazardSelectionState',
   default: false,
   effects: (id) => [
+    ({ onSet }) => {
+      onSet((newVisibility) => {
+        const url = new URL(window.location.href);
+        url.searchParams.set(id, newVisibility.toString());
+        window.history.replaceState({}, '', url.toString());
+      });
+    },
     urlSyncEffect({
       storeKey: 'url-json',
-      itemKey: id.toString(),
+      itemKey: id,
       refine: bool(),
     }),
   ],

--- a/frontend/src/lib/state/sections.ts
+++ b/frontend/src/lib/state/sections.ts
@@ -6,6 +6,13 @@ export const sectionVisibilityState = atomFamily<boolean, string>({
   key: 'sectionVisibilityState',
   default: false,
   effects: (id) => [
+    ({ onSet }) => {
+      onSet((newVisibility) => {
+        const url = new URL(window.location.href);
+        url.searchParams.set(id, newVisibility.toString());
+        window.history.replaceState({}, '', url.toString());
+      });
+    },
     urlSyncEffect({
       storeKey: 'url-json',
       itemKey: id,


### PR DESCRIPTION
`urlSyncEffect` isn't writing sidebar section visibility states or hazard visibility states to URL params. This commit adds effects which manually write to the URL whenever these states change.