### PR TITLE
chore(frontend): 0.4.21

### DIFF
--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -1,7 +1,7 @@
 # Staging environment - as production except for domain
 services:
   frontend:
-    image: ghcr.io/nismod/jsrat-frontend:0.4.20
+    image: ghcr.io/nismod/jsrat-frontend:0.4.21
     platform: linux/amd64
     build: ./frontend
     ports:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irv-jamaica",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irv-jamaica",
-      "version": "0.4.20",
+      "version": "0.4.21",
       "dependencies": {
         "@deck.gl/extensions": "8.9",
         "@emotion/react": "^11.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "irv-jamaica",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
- fix: sidebar visibility params in the URL.
- build: frontend now builds with Vite 6.
- dependency updates.
- fixes for linter warnings.