### PR TITLE
build(pixel_driller): use python:3.12-slim

### DIFF
--- a/pixel_driller/Dockerfile
+++ b/pixel_driller/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.12-slim
 
 WORKDIR /code
 


### PR DESCRIPTION
Build with `python:3.12-slim` for a smaller image.