### PR TITLE
build(pixel-driller): add g++ to Docker build

### DIFF
--- a/pixel_driller/Dockerfile
+++ b/pixel_driller/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /code
 
 COPY . /code
 
-RUN apt-get update && apt-get install -y libgdal-dev
+RUN apt-get update && apt-get install -y libgdal-dev g++
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 
 #CMD ["fastapi", "run", "main.py", "--port", "80"]


### PR DESCRIPTION
The `pixel-driller` image needs `g++` to build a couple of Python packages from source on Apple Macs.