### PR TITLE
fix(frontend): get feature IDs for adaptation maps

### DIFF
--- a/frontend/src/lib/deck/layers/data-loader-layer.ts
+++ b/frontend/src/lib/deck/layers/data-loader-layer.ts
@@ -13,7 +13,8 @@ export function dataLoaderLayer(tileProps, { dataLoader }: DataLoaderOptions) {
     tile: { content },
   } = tileProps;
   if (content && dataLoader) {
-    const ids: number[] = !dataLoader.hasData ? content.map(getFeatureId) : [];
+    const ids: number[] = !dataLoader.hasData ? content.map((f) => getFeatureId(f, 'id')) : [];
+    console.log('dataLoaderLayer', ids);
 
     dataLoader.loadDataForIds(ids);
   }


### PR DESCRIPTION
Fix feature IDs for data loader layers, which were broken in #266.