### PR TITLE
build(deps): bump TypeScript to 5.8

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -88,7 +88,7 @@
         "openapi-typescript-codegen": "^0.21.0",
         "prettier": "^3.2.5",
         "storybook": "^8.2.8",
-        "typescript": "^5.4.5",
+        "typescript": "^5.8.2",
         "typescript-eslint": "^8.26.0",
         "vite": "^6.0.7",
         "vite-tsconfig-paths": "^5.1.4",
@@ -19568,9 +19568,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,7 +84,7 @@
     "openapi-typescript-codegen": "^0.21.0",
     "prettier": "^3.2.5",
     "storybook": "^8.2.8",
-    "typescript": "^5.4.5",
+    "typescript": "^5.8.2",
     "typescript-eslint": "^8.26.0",
     "vite": "^6.0.7",
     "vite-tsconfig-paths": "^5.1.4",
@@ -109,7 +109,10 @@
   ],
   "overrides": {
     "react": "^18.3.0",
-    "react-dom": "^18.3.0"
+    "react-dom": "^18.3.0",
+    "eslint-plugin-storybook": {
+      "typescript": "$typescript"
+    }
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Note that `eslint-plugin-storybook` expects `typescript < 5.8.0`. See https://github.com/storybookjs/eslint-plugin-storybook/issues/193