### PR TITLE
chore(frontend) v0.4.23

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irv-jamaica",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irv-jamaica",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "dependencies": {
         "@deck.gl/extensions": "^9.1.4",
         "@emotion/react": "^11.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "irv-jamaica",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
- major version upgrades for `deck.gl`, `react-map.gl`, `maplibre-gl`, `@loaders.gl`, and `@turf` packages.
- minor and patch updates for other outdated dependencies.