### PR TITLE
build(deps): pin deck.gl to 9.1.4

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "irv-jamaica",
       "version": "0.4.23",
       "dependencies": {
-        "@deck.gl/extensions": "^9.1.4",
+        "@deck.gl/extensions": "9.1.4",
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@loaders.gl/core": "^4.3.3",
@@ -29,7 +29,7 @@
         "d3-ease": "^3.0.1",
         "d3-scale": "^4.0.2",
         "d3-scale-chromatic": "^3.0.0",
-        "deck.gl": "^9.1.4",
+        "deck.gl": "9.1.4",
         "immer": "^10.1.1",
         "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@deck.gl/extensions": "^9.1.4",
+    "@deck.gl/extensions": "9.1.4",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@loaders.gl/core": "^4.3.3",
@@ -25,7 +25,7 @@
     "d3-ease": "^3.0.1",
     "d3-scale": "^4.0.2",
     "d3-scale-chromatic": "^3.0.0",
-    "deck.gl": "^9.1.4",
+    "deck.gl": "9.1.4",
     "immer": "^10.1.1",
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Pin `deck.gl` to 9.1.4, since 9.1.5 breaks the data map.