### PR TITLE
chore(frontend): 0.4.24

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irv-jamaica",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irv-jamaica",
-      "version": "0.4.23",
+      "version": "0.4.24",
       "dependencies": {
         "@deck.gl/extensions": "9.1.4",
         "@emotion/react": "^11.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "irv-jamaica",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
- feat: storm raster maps showing return periods for fixed wind speeds.
- dependency updates.
- pin `deck.gl` to 9.1.4 to avoid a bug in the data map with 9.1.5.