### PR TITLE
refactor(frontend): use react-query keys in fetcher functions

### DIFF
--- a/frontend/src/lib/map/legend/use-color-map-values.ts
+++ b/frontend/src/lib/map/legend/use-color-map-values.ts
@@ -1,8 +1,10 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-async function fetchColorMapValues(colorScheme: string) {
-  const response = await fetch(`/raster/colormap?colormap=${colorScheme}&stretch_range=[0,1]`);
+async function fetchColorMapValues({ queryKey }) {
+  const [endpoint, query] = queryKey;
+  const searchParams = new URLSearchParams(query);
+  const response = await fetch(`${endpoint}?${searchParams}`);
   if (!response.ok) {
     throw new Error('Failed to fetch color map values');
   }
@@ -11,14 +13,18 @@ async function fetchColorMapValues(colorScheme: string) {
 
 export function useRasterColorMapValues(colorScheme: string, stretchRange: [number, number]) {
   const [rangeMin, rangeMax] = stretchRange;
+  const query = {
+    colormap: colorScheme,
+    stretch_range: '[0,1]',
+  }
 
   const {
     isLoading,
     error,
     data = {},
   } = useQuery({
-    queryKey: ['colormaps', colorScheme],
-    queryFn: () => fetchColorMapValues(colorScheme),
+    queryKey: ['/raster/colormap', query],
+    queryFn: fetchColorMapValues,
   });
   const { colormap = [] } = data;
 


### PR DESCRIPTION
Refactor `react-query` fetcher functions to take `{ queryKey }` as an argument.