### PR TITLE
chore(frontend): 0.4.25

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irv-jamaica",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irv-jamaica",
-      "version": "0.4.24",
+      "version": "0.4.25",
       "dependencies": {
         "@deck.gl/extensions": "^9.1.4",
         "@emotion/react": "^11.7.1",
@@ -3199,21 +3199,20 @@
       }
     },
     "node_modules/@esri/calcite-components": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-3.0.3.tgz",
-      "integrity": "sha512-MTaNCQuxFe2VkCUzeQ3CG3i5SND/fH/hr8lmcgemPMcqRZBTx4xHE/PRBZ2nLS1jgjgMJT1Qd+W3MBQpfsB1eQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-3.1.0.tgz",
+      "integrity": "sha512-tfuxpwHRftyREO9vAcuuWf9KGaSc9UZrw75w/XZsU6fz33biMrANhhFEoTx5dTMALj68Fxnxibpiyg1vv9BRwQ==",
       "license": "SEE LICENSE.md",
       "peer": true,
       "dependencies": {
-        "@arcgis/components-controllers": "^4.32.0-next.129",
-        "@arcgis/components-utils": "^4.32.0-next.129",
-        "@arcgis/lumina": "^4.32.0-next.129",
-        "@esri/calcite-ui-icons": "4.0.0",
+        "@arcgis/components-controllers": "^4.32.12",
+        "@arcgis/components-utils": "^4.32.12",
+        "@arcgis/lumina": "^4.32.12",
+        "@esri/calcite-ui-icons": "4.1.0",
         "@floating-ui/dom": "^1.6.12",
         "@floating-ui/utils": "^0.2.8",
-        "@types/color": "^4.2.0",
         "@types/sortablejs": "^1.15.8",
-        "color": "^4.2.3",
+        "color": "^5.0.0",
         "composed-offset-position": "^0.0.6",
         "dayjs": "^1.11.13",
         "focus-trap": "^7.6.2",
@@ -3238,9 +3237,9 @@
       }
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-4.0.0.tgz",
-      "integrity": "sha512-LcL35NydvXI93u/pU6fXXg/kY2LXR5zWEvOytDoqgu1GPL7xgvrYuIutkvuDJpDh3PhcGXsCX4Axw5i6sCEXsA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-4.1.0.tgz",
+      "integrity": "sha512-j8uPnbsrPklQVRnaL2qg0wfosavdnQXARr7ckpiIpzAX75MGmNGLg4QKfpAeQrXGJ/xznWWAc+GtAMY8aDrLsw==",
       "license": "SEE LICENSE.md",
       "peer": true,
       "bin": {
@@ -4795,31 +4794,31 @@
       }
     },
     "node_modules/@mui/base": {
-      "version": "5.0.0-beta.70",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.70.tgz",
-      "integrity": "sha512-Tb/BIhJzb0pa5zv/wu7OdokY9ZKEDqcu1BDFnohyvGCoHuSXbEr90rPq1qeNW3XvTBIbNWHEF7gqge+xpUo6tQ==",
+      "version": "5.0.0-beta.42",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.42.tgz",
+      "integrity": "sha512-fWRiUJVCHCPF+mxd5drn08bY2qRw3jj5f1SSQdUXmaJ/yKpk23ys8MgLO2KGVTRtbks/+ctRfgffGPbXifj0Ug==",
       "deprecated": "This package has been replaced by @base-ui-components/react",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@floating-ui/react-dom": "^2.1.1",
-        "@mui/types": "~7.2.24",
-        "@mui/utils": "^6.4.8",
+        "@babel/runtime": "^7.24.4",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^6.0.0-alpha.1",
         "@popperjs/core": "^2.11.8",
-        "clsx": "^2.1.1",
+        "clsx": "^2.1.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4828,9 +4827,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.8.tgz",
-      "integrity": "sha512-vjP4+A1ybyCRhDZC7r5EPWu/gLseFZxaGyPdDl94vzVvk6Yj6gahdaqcjbhkaCrJjdZj90m3VioltWPAnWF/zw==",
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.9.tgz",
+      "integrity": "sha512-3UvsvOjqZJcokHKSzA1lskj2XMM/G5GBgge6ykwmAij2pGGxydGxAXirQlLaeoMwTKDS6BcrLqPZyPVwzri20A==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4838,9 +4837,9 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.4.8.tgz",
-      "integrity": "sha512-LKGWiLWRyoOw3dWxZQ+lV//mK+4DVTTAiLd2ljmJdD6XV0rDB8JFKjRD9nyn9cJAU5XgWnii7ZR3c93ttUnMKg==",
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.4.9.tgz",
+      "integrity": "sha512-a8l63VIscBteJlh31R88aVgHelCcrhl3Rk0GnN8znTsGhcam9mFeo4Xlw+gLUYQP7mxVcVt3WP9XJkwXWZflnw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0"
@@ -4853,7 +4852,7 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^6.4.8",
+        "@mui/material": "^6.4.9",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -4864,21 +4863,21 @@
       }
     },
     "node_modules/@mui/lab": {
-      "version": "6.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-6.0.0-beta.31.tgz",
-      "integrity": "sha512-iZjchha0XznSqp5fKtgsozz/zZEjJFG8s4EeBypdlZEIcHvRKx3hUKBuaFM6B/PiC2kJrNMQSi5W2Fjio5sLKQ==",
+      "version": "6.0.0-dev.240424162023-9968b4889d",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-6.0.0-dev.240424162023-9968b4889d.tgz",
+      "integrity": "sha512-iKFAz7/EeWI4PaFsP4jK2FcYJmUYDBkn3XZwpQSAl5806yYq5J2U2mPQLuZBdhrH50gT2O98p95i3vwL4YBwAg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/base": "5.0.0-beta.70",
-        "@mui/system": "^6.4.8",
-        "@mui/types": "~7.2.24",
-        "@mui/utils": "^6.4.8",
-        "clsx": "^2.1.1",
+        "@babel/runtime": "^7.24.4",
+        "@mui/base": "5.0.0-beta.42",
+        "@mui/system": "^6.0.0-dev.240424162023-9968b4889d",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^6.0.0-alpha.3",
+        "clsx": "^2.1.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4887,11 +4886,10 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material": "^6.4.8",
-        "@mui/material-pigment-css": "^6.4.8",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+        "@mui/material": "^6.0.0-dev.240424162023-9968b4889d",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -4900,64 +4898,12 @@
         "@emotion/styled": {
           "optional": true
         },
-        "@mui/material-pigment-css": {
-          "optional": true
-        },
         "@types/react": {
           "optional": true
         }
       }
     },
-    "node_modules/@mui/material": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.4.8.tgz",
-      "integrity": "sha512-5S9UTjKZZBd9GfbcYh/nYfD9cv6OXmj5Y7NgKYfk7JcSoshp8/pW5zP4wecRiroBSZX8wcrywSgogpVNO+5W0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/core-downloads-tracker": "^6.4.8",
-        "@mui/system": "^6.4.8",
-        "@mui/types": "~7.2.24",
-        "@mui/utils": "^6.4.8",
-        "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.12",
-        "clsx": "^2.1.1",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.0.0",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^6.4.8",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@mui/material-pigment-css": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/private-theming": {
+    "node_modules/@mui/lab/node_modules/@mui/private-theming": {
       "version": "6.4.8",
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.8.tgz",
       "integrity": "sha512-sWwQoNSn6elsPTAtSqCf+w5aaGoh7AASURNmpy+QTTD/zwJ0Jgwt0ZaaP6mXq2IcgHxYnYloM/+vJgHPMkRKTQ==",
@@ -4984,10 +4930,10 @@
         }
       }
     },
-    "node_modules/@mui/styled-engine": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.4.8.tgz",
-      "integrity": "sha512-oyjx1b1FvUCI85ZMO4trrjNxGm90eLN3Ohy0AP/SqK5gWvRQg1677UjNf7t6iETOKAleHctJjuq0B3aXO2gtmw==",
+    "node_modules/@mui/lab/node_modules/@mui/styled-engine": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.4.9.tgz",
+      "integrity": "sha512-qZRWO0cT407NI4ZRjZcH+1SOu8f3JzLHqdMlg52GyEufM9pkSZFnf7xjpwnlvkixcGjco6wLlMD0VB43KRcBuA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
@@ -5018,15 +4964,15 @@
         }
       }
     },
-    "node_modules/@mui/system": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.4.8.tgz",
-      "integrity": "sha512-gV7iBHoqlsIenU2BP0wq14BefRoZcASZ/4LeyuQglayBl+DfLX5rEd3EYR3J409V2EZpR0NOM1LATAGlNk2cyA==",
+    "node_modules/@mui/lab/node_modules/@mui/system": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.4.9.tgz",
+      "integrity": "sha512-JOj7efXGtZn+NIzX8KDyMpO1QKc0DhilPBsxvci1xAvI1e5AtAtfzrEuV5ZvN+lz2BDuzngCWlllnqQ/cg40RQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/private-theming": "^6.4.8",
-        "@mui/styled-engine": "^6.4.8",
+        "@mui/styled-engine": "^6.4.9",
         "@mui/types": "~7.2.24",
         "@mui/utils": "^6.4.8",
         "clsx": "^2.1.1",
@@ -5058,11 +5004,358 @@
         }
       }
     },
-    "node_modules/@mui/types": {
+    "node_modules/@mui/lab/node_modules/@mui/types": {
       "version": "7.2.24",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
       "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.4.9.tgz",
+      "integrity": "sha512-+5dExw9xUUFujIW889gB3qrfjeNo3YjYW7aWVZ6BlBIJnKpJ0jNcYZJpBUFoXt/FUV5Wy1V+/+XzR3Is2mXX2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/core-downloads-tracker": "^6.4.9",
+        "@mui/system": "^6.4.9",
+        "@mui/types": "~7.2.24",
+        "@mui/utils": "^6.4.8",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^6.4.9",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/@mui/private-theming": {
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.8.tgz",
+      "integrity": "sha512-sWwQoNSn6elsPTAtSqCf+w5aaGoh7AASURNmpy+QTTD/zwJ0Jgwt0ZaaP6mXq2IcgHxYnYloM/+vJgHPMkRKTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/utils": "^6.4.8",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/@mui/styled-engine": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.4.9.tgz",
+      "integrity": "sha512-qZRWO0cT407NI4ZRjZcH+1SOu8f3JzLHqdMlg52GyEufM9pkSZFnf7xjpwnlvkixcGjco6wLlMD0VB43KRcBuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/@mui/system": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.4.9.tgz",
+      "integrity": "sha512-JOj7efXGtZn+NIzX8KDyMpO1QKc0DhilPBsxvci1xAvI1e5AtAtfzrEuV5ZvN+lz2BDuzngCWlllnqQ/cg40RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/private-theming": "^6.4.8",
+        "@mui/styled-engine": "^6.4.9",
+        "@mui/types": "~7.2.24",
+        "@mui/utils": "^6.4.8",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/@mui/types": {
+      "version": "7.2.24",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
+      "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.0.0.tgz",
+      "integrity": "sha512-I6iUTlpQEsJ7G2+88aLriyLUtTZp7a3p6l62OQtRo02PAQ4NznYzaN/ck1PQbcKwKdvPBpshdDdV3zdGioIiJQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "@mui/utils": "^7.0.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/private-theming/node_modules/@mui/utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.0.0.tgz",
+      "integrity": "sha512-oCRO9o08klpO13lZvPUt+ocmkyMlnAk76Eo8IIel6dcCBQQ0sTI5QNiSMzGC+JvusfPMGdvgIOVtHeyhRijJfQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "@mui/types": "^7.4.0",
+        "@types/prop-types": "^15.7.14",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.0.0.tgz",
+      "integrity": "sha512-Rm2q8FVo++rwgaMZil+0bJ6ZRY8Rm0UvvN3t/mXvUnyZA3+NqYMFBomS85LzriaEIY5hTSl9PE1z9l7Pox3aeA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.0.0.tgz",
+      "integrity": "sha512-fXUtOdgHRN/NLuv3kNCtqN4/IS7FXXRx7W45HU4FMpyq31JgcUPJpt7WBsU+Vvcn2lffk4YzavE4wc0Q3kUaiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "@mui/private-theming": "^7.0.0",
+        "@mui/styled-engine": "^7.0.0",
+        "@mui/types": "^7.4.0",
+        "@mui/utils": "^7.0.0",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system/node_modules/@mui/utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.0.0.tgz",
+      "integrity": "sha512-oCRO9o08klpO13lZvPUt+ocmkyMlnAk76Eo8IIel6dcCBQQ0sTI5QNiSMzGC+JvusfPMGdvgIOVtHeyhRijJfQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "@mui/types": "^7.4.0",
+        "@types/prop-types": "^15.7.14",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-TxJ4ezEeedWHBjOmLtxI203a9DII9l4k83RXmz1PYSAmnyEcK2PglTNmJGxswC/wM5cdl9ap2h8lnXvt2swAGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10"
+      },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -5095,6 +5388,20 @@
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils/node_modules/@mui/types": {
+      "version": "7.2.24",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
+      "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -7493,9 +7800,9 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.6",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.6.tgz",
-      "integrity": "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
+      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7510,33 +7817,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/color": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/color/-/color-4.2.0.tgz",
-      "integrity": "sha512-6+xrIRImMtGAL2X3qYkd02Mgs+gFGs+WsK0b7VVMaO4mYRISwyTjcqNrO0mNSmYEoq++rSLDB2F5HDNmqfOe+A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/color-convert": "*"
-      }
-    },
-    "node_modules/@types/color-convert": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.4.tgz",
-      "integrity": "sha512-Ub1MmDdyZ7mX//g25uBAoH/mWGd9swVbt8BseymnaE18SU4po/PjmCrHxqIIRjBo3hV/vh1KGr0eMxUhp+t+dQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/color-name": "^1.1.0"
-      }
-    },
-    "node_modules/@types/color-name": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.5.tgz",
-      "integrity": "sha512-j2K5UJqGTxeesj6oQuGpMgifpT5k9HprgQd8D1Y0lOFqKHl3PJu5GMeS4Y5EgjS55AE6OQxf8mPED9uaGbf4Cg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
@@ -8126,10 +8406,10 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@unrs/rspack-resolver-binding-darwin-arm64": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-darwin-arm64/-/rspack-resolver-binding-darwin-arm64-1.2.2.tgz",
-      "integrity": "sha512-i7z0B+C0P8Q63O/5PXJAzeFtA1ttY3OR2VSJgGv18S+PFNwD98xHgAgPOT1H5HIV6jlQP8Avzbp09qxJUdpPNw==",
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-PdaB3zQ6Z3Jn+m/5ajYCbR0tQFFTwr3ddJ/SH2L+AAKBUfEKJHUv/dZIJNKkCq2YVJNL/SfdksRe+nU3e5f2Lg==",
       "cpu": [
         "arm64"
       ],
@@ -8140,10 +8420,10 @@
         "darwin"
       ]
     },
-    "node_modules/@unrs/rspack-resolver-binding-darwin-x64": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-darwin-x64/-/rspack-resolver-binding-darwin-x64-1.2.2.tgz",
-      "integrity": "sha512-YEdFzPjIbDUCfmehC6eS+AdJYtFWY35YYgWUnqqTM2oe/N58GhNy5yRllxYhxwJ9GcfHoNc6Ubze1yjkNv+9Qg==",
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-SyrYaFWaWla0PK5Bf0d8zXbK/OiiPO/nPyksT9JPzgzP2Qt7GTwihSA+lwdbu0MJfG/ppEVou/qedmhbevJPGQ==",
       "cpu": [
         "x64"
       ],
@@ -8154,10 +8434,10 @@
         "darwin"
       ]
     },
-    "node_modules/@unrs/rspack-resolver-binding-freebsd-x64": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-freebsd-x64/-/rspack-resolver-binding-freebsd-x64-1.2.2.tgz",
-      "integrity": "sha512-TU4ntNXDgPN2giQyyzSnGWf/dVCem5lvwxg0XYvsvz35h5H19WrhTmHgbrULMuypCB3aHe1enYUC9rPLDw45mA==",
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.3.1.tgz",
+      "integrity": "sha512-Ky60j3ZLqbM0Rbwo04htABNTWRDNx6GttGX+L9ixE1T5/XBDmrMSOqxvWhqfVeZHskQ3/pCVEH/ylmofJ6mFZg==",
       "cpu": [
         "x64"
       ],
@@ -8168,10 +8448,10 @@
         "freebsd"
       ]
     },
-    "node_modules/@unrs/rspack-resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm-gnueabihf/-/rspack-resolver-binding-linux-arm-gnueabihf-1.2.2.tgz",
-      "integrity": "sha512-ik3w4/rU6RujBvNWiDnKdXi1smBhqxEDhccNi/j2rHaMjm0Fk49KkJ6XKsoUnD2kZ5xaMJf9JjailW/okfUPIw==",
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.3.1.tgz",
+      "integrity": "sha512-Un+2iis8yZMkP0qLDqjAEoRjsw40jvrgyaLtaeVk0G77AXdo0QrpUq1dqXvE9M9lVVJj7kXfaDtE7CBZ1EWmoQ==",
       "cpu": [
         "arm"
       ],
@@ -8182,10 +8462,24 @@
         "linux"
       ]
     },
-    "node_modules/@unrs/rspack-resolver-binding-linux-arm64-gnu": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm64-gnu/-/rspack-resolver-binding-linux-arm64-gnu-1.2.2.tgz",
-      "integrity": "sha512-fp4Azi8kHz6TX8SFmKfyScZrMLfp++uRm2srpqRjsRZIIBzH74NtSkdEUHImR4G7f7XJ+sVZjCc6KDDK04YEpQ==",
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.3.1.tgz",
+      "integrity": "sha512-Vj6LgN8zTwfiPSTtaneKb3kWS0kc6qmZTASCUg5oPviXJh9WsXwRKQE/biYwX0C/YDY5S1Dqs6AV7R5i3X95ew==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.3.1.tgz",
+      "integrity": "sha512-aA4KA/92L62KLZf7d2b6JSrRCRpenFIKuIyLckf0DqLSEavKq3Iql8xU7T7OW8ite0+b4uQlx7RjkCFsME8KYg==",
       "cpu": [
         "arm64"
       ],
@@ -8196,10 +8490,10 @@
         "linux"
       ]
     },
-    "node_modules/@unrs/rspack-resolver-binding-linux-arm64-musl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm64-musl/-/rspack-resolver-binding-linux-arm64-musl-1.2.2.tgz",
-      "integrity": "sha512-gMiG3DCFioJxdGBzhlL86KcFgt9HGz0iDhw0YVYPsShItpN5pqIkNrI+L/Q/0gfDiGrfcE0X3VANSYIPmqEAlQ==",
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.3.1.tgz",
+      "integrity": "sha512-WyVE0f4gks4v0kL4B4l5SB7GrEZvT7ZYbZjdVDHRpnrhYjEoEj/3G1Otu7XAkf1ykXZ65dVLqPBVeNn8OYbsPA==",
       "cpu": [
         "arm64"
       ],
@@ -8210,10 +8504,38 @@
         "linux"
       ]
     },
-    "node_modules/@unrs/rspack-resolver-binding-linux-x64-gnu": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-x64-gnu/-/rspack-resolver-binding-linux-x64-gnu-1.2.2.tgz",
-      "integrity": "sha512-n/4n2CxaUF9tcaJxEaZm+lqvaw2gflfWQ1R9I7WQgYkKEKbRKbpG/R3hopYdUmLSRI4xaW1Cy0Bz40eS2Yi4Sw==",
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.3.1.tgz",
+      "integrity": "sha512-BcF2tCI8B+oD1F+6jNxZxUWKzaCr4aNCrPnU3K/OLmMTdttHeiS2u3KvwZmgpkEc36gIBx65P7VFh4rBhcOQKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.3.1.tgz",
+      "integrity": "sha512-stCbOVTMrYsCyKfSkr8mvdUz78kkHCqMSy60LuK245pJByFgs4vG8Qpehr4jDHORHve4OOXf3ZJP5vEJuil2ng==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.3.1.tgz",
+      "integrity": "sha512-lZZunwEvM6mCbibcS7Jxd2fYT9D/aRjjw24p0ua43lIymkzhAUA1UI11q6MWmZF0EgrLoFfAS73ExjyU5ghTWA==",
       "cpu": [
         "x64"
       ],
@@ -8224,10 +8546,10 @@
         "linux"
       ]
     },
-    "node_modules/@unrs/rspack-resolver-binding-linux-x64-musl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-x64-musl/-/rspack-resolver-binding-linux-x64-musl-1.2.2.tgz",
-      "integrity": "sha512-cHyhAr6rlYYbon1L2Ag449YCj3p6XMfcYTP0AQX+KkQo025d1y/VFtPWvjMhuEsE2lLvtHm7GdJozj6BOMtzVg==",
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.3.1.tgz",
+      "integrity": "sha512-mhAUo+vj5jO76AKhy/IP7ALzGw0m/6EkOIZYrW64AlmGlm094CvHzQqHz/nAW3ffQLZMzhBez8AuhZwdgCeqrA==",
       "cpu": [
         "x64"
       ],
@@ -8238,10 +8560,10 @@
         "linux"
       ]
     },
-    "node_modules/@unrs/rspack-resolver-binding-wasm32-wasi": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-wasm32-wasi/-/rspack-resolver-binding-wasm32-wasi-1.2.2.tgz",
-      "integrity": "sha512-eogDKuICghDLGc32FtP+WniG38IB1RcGOGz0G3z8406dUdjJvxfHGuGs/dSlM9YEp/v0lEqhJ4mBu6X2nL9pog==",
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.3.1.tgz",
+      "integrity": "sha512-2eKumvKdxBlvDjgbv5I/slDlw0lyRno0VsOPNl9L4cyO/LftBoPPZUEhRpN/JuEjX0PljEbAPG9j1Kd1EpTV6w==",
       "cpu": [
         "wasm32"
       ],
@@ -8255,10 +8577,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@unrs/rspack-resolver-binding-win32-arm64-msvc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-win32-arm64-msvc/-/rspack-resolver-binding-win32-arm64-msvc-1.2.2.tgz",
-      "integrity": "sha512-7sWRJumhpXSi2lccX8aQpfFXHsSVASdWndLv8AmD8nDRA/5PBi8IplQVZNx2mYRx6+Bp91Z00kuVqpXO9NfCTg==",
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.3.1.tgz",
+      "integrity": "sha512-4McXLSAp5lcg94AuKQ/SefXswIuZbO4VDzBSvcKP7Hy0mEJAuxKfGKUeDSFobu/CBDPJ9emhDJHLRbo3k3AcGw==",
       "cpu": [
         "arm64"
       ],
@@ -8269,10 +8591,24 @@
         "win32"
       ]
     },
-    "node_modules/@unrs/rspack-resolver-binding-win32-x64-msvc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-win32-x64-msvc/-/rspack-resolver-binding-win32-x64-msvc-1.2.2.tgz",
-      "integrity": "sha512-hewo/UMGP1a7O6FG/ThcPzSJdm/WwrYDNkdGgWl6M18H6K6MSitklomWpT9MUtT5KGj++QJb06va/14QBC4pvw==",
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.3.1.tgz",
+      "integrity": "sha512-8k9ioJqL+0HlFQW+J795Iw5Eowfhis3xhY3W0EfOFvUCXYhilGPBuHGTSh3t4M/pMC49vBJ0ZTpsR/jk8oAWIg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.3.1.tgz",
+      "integrity": "sha512-/dargLEQa2N4o/lNml09ff2P11XpBq50Jpjk8cMsDvj8YmzKLTzqguobXavj63ZWE9mN+Y3DTEbVpQOk+uY9XQ==",
       "cpu": [
         "x64"
       ],
@@ -9883,17 +10219,17 @@
       "license": "MIT"
     },
     "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.0.tgz",
+      "integrity": "sha512-16BlyiuyLq3MLxpRWyOTiWsO3ii/eLQLJUQXBSNcxMBBSnyt1ee9YUdaozQp03ifwm5woztEZGDbk9RGVuCsdw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
+        "color-convert": "^3.0.1",
+        "color-string": "^2.0.0"
       },
       "engines": {
-        "node": ">=12.5.0"
+        "node": ">=18"
       }
     },
     "node_modules/color-convert": {
@@ -9915,14 +10251,49 @@
       "license": "MIT"
     },
     "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.0.1.tgz",
+      "integrity": "sha512-5z9FbYTZPAo8iKsNEqRNv+OlpBbDcoE+SY9GjLfDUHEfcNNV7tS9eSAlFHEaub/r5tBL9LtskAeq1l9SaoZ5tQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.0.1.tgz",
+      "integrity": "sha512-5kQah2eolfQV7HCrxtsBBArPfT5dwaKYMCXeMQsdRO7ihTO/cuNLGjd50ITCDn+ZU/YbS0Go64SjP9154eopxg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/colorbrewer": {
@@ -11063,9 +11434,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.123",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.123.tgz",
-      "integrity": "sha512-refir3NlutEZqlKaBLK0tzlVLe5P2wDKS7UQt/3SpibizgsRAPOsqQC3ffw1nlv3ze5gjRQZYHoPymgVZkplFA==",
+      "version": "1.5.124",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.124.tgz",
+      "integrity": "sha512-riELkpDUqBi00gqreV3RIGoowxGrfueEKBd6zPdOk/I8lvuFpBGNkYoHof3zUHbiTBsIU8oxdIIL/WNrAG1/7A==",
       "dev": true,
       "license": "ISC"
     },
@@ -11474,18 +11845,18 @@
       }
     },
     "node_modules/eslint-import-resolver-typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.2.3.tgz",
-      "integrity": "sha512-trG0f6LY+g7CJCV8AN6O+cU5B13tONNDF9ZcnxDtUQQqvufNFDn3zcb/EIslXHwl1IjloZoVvOOcKtBaO9HlBw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.2.4.tgz",
+      "integrity": "sha512-aXuJ7khvdh/n6UGQ6bk2Hqdk0kJdrkUCxRQy62QXB+aJ9xaCZnynFOMqhwGxOlWnt6k2fHwIPAOaOM5dBCmFZg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "debug": "^4.4.0",
         "get-tsconfig": "^4.10.0",
         "is-bun-module": "^2.0.0",
-        "rspack-resolver": "^1.2.2",
         "stable-hash": "^0.0.5",
-        "tinyglobby": "^0.2.12"
+        "tinyglobby": "^0.2.12",
+        "unrs-resolver": "^1.3.1"
       },
       "engines": {
         "node": "^16.17.0 || >=18.6.0"
@@ -18198,29 +18569,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/rspack-resolver": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rspack-resolver/-/rspack-resolver-1.2.2.tgz",
-      "integrity": "sha512-Fwc19jMBA3g+fxDJH2B4WxwZjE0VaaOL7OX/A4Wn5Zv7bOD/vyPZhzXfaO73Xc2GAlfi96g5fGUa378WbIGfFw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/JounQin"
-      },
-      "optionalDependencies": {
-        "@unrs/rspack-resolver-binding-darwin-arm64": "1.2.2",
-        "@unrs/rspack-resolver-binding-darwin-x64": "1.2.2",
-        "@unrs/rspack-resolver-binding-freebsd-x64": "1.2.2",
-        "@unrs/rspack-resolver-binding-linux-arm-gnueabihf": "1.2.2",
-        "@unrs/rspack-resolver-binding-linux-arm64-gnu": "1.2.2",
-        "@unrs/rspack-resolver-binding-linux-arm64-musl": "1.2.2",
-        "@unrs/rspack-resolver-binding-linux-x64-gnu": "1.2.2",
-        "@unrs/rspack-resolver-binding-linux-x64-musl": "1.2.2",
-        "@unrs/rspack-resolver-binding-wasm32-wasi": "1.2.2",
-        "@unrs/rspack-resolver-binding-win32-arm64-msvc": "1.2.2",
-        "@unrs/rspack-resolver-binding-win32-x64-msvc": "1.2.2"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -18554,23 +18902,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -19916,6 +20247,33 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.3.1.tgz",
+      "integrity": "sha512-8OaGhiFH/BLD8CPBPs1y/OLlMvxmZs5tqLT/7FO49LyG3oXYEx20tNcOrLZzzKWYhnCprv60tzJjbZgzWZvHvg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/JounQin"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-darwin-arm64": "1.3.1",
+        "@unrs/resolver-binding-darwin-x64": "1.3.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.3.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.3.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.3.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.3.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.3.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.3.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.3.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.3.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.3.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.3.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.3.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.3.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.3.1"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "irv-jamaica",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
- dependency updates, including deck.gl 9.1.8.
- swap `useFetch` for `useQuery` (`@tanstack/react-query`.)