### PR TITLE
build(deps-dev): migrate API client to @hey-api/openapi-ts

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -8,6 +8,9 @@ import typescript from 'typescript-eslint';
 import storybook from 'eslint-plugin-storybook';
 
 export default [
+  {
+    ignores: ['src/lib/api-client'],
+  },
   js.configs.recommended,
   reactRecommended,
   reactJSXRuntime,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -48,6 +48,7 @@
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^1.6.1",
+        "@hey-api/openapi-ts": "^0.29.0",
         "@rollup/plugin-url": "^8.0.2",
         "@storybook/addon-a11y": "^8.2.8",
         "@storybook/addon-essentials": "^8.2.8",
@@ -85,7 +86,6 @@
         "http-server": "^14.1.1",
         "msw": "^2.3.5",
         "msw-storybook-addon": "^2.0.3",
-        "openapi-typescript-codegen": "^0.29.0",
         "prettier": "^3.2.5",
         "storybook": "^8.2.8",
         "typescript": "^5.8.2",
@@ -114,24 +114,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.9.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
-      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.15",
-        "js-yaml": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@arcgis/components-controllers": {
@@ -3294,6 +3276,66 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@hey-api/openapi-ts": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.29.2.tgz",
+      "integrity": "sha512-vMiflCb58h8JweYRE3OA6mDj9316dQEIdWsa0kJlk6bS4461WKI6av3nHkCJeL7pi3oXobeAl1SMC13Vfz+Oow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "11.5.4",
+        "camelcase": "8.0.0",
+        "commander": "12.0.0",
+        "handlebars": "4.7.8"
+      },
+      "bin": {
+        "openapi-ts": "bin/index.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@hey-api/openapi-ts/node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.5.4",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.5.4.tgz",
+      "integrity": "sha512-o2fsypTGU0WxRxbax8zQoHiIB4dyrkwYfcm8TxZ+bx9pCzcWZbQtiMqpgBvWA/nJ2TrGjK5adCLfTH8wUeU/Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@hey-api/openapi-ts/node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@hey-api/openapi-ts/node_modules/commander": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@humanfs/core": {
@@ -12325,21 +12367,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -16672,23 +16699,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/openapi-typescript-codegen": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/openapi-typescript-codegen/-/openapi-typescript-codegen-0.29.0.tgz",
-      "integrity": "sha512-/wC42PkD0LGjDTEULa/XiWQbv4E9NwLjwLjsaJ/62yOsoYhwvmBR31kPttn1DzQ2OlGe5stACcF/EIkZk43M6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^11.5.4",
-        "camelcase": "^6.3.0",
-        "commander": "^12.0.0",
-        "fs-extra": "^11.2.0",
-        "handlebars": "^4.7.8"
-      },
-      "bin": {
-        "openapi": "bin/index.js"
       }
     },
     "node_modules/opener": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.6.1",
+    "@hey-api/openapi-ts": "^0.29.0",
     "@rollup/plugin-url": "^8.0.2",
     "@storybook/addon-a11y": "^8.2.8",
     "@storybook/addon-essentials": "^8.2.8",
@@ -81,7 +82,6 @@
     "http-server": "^14.1.1",
     "msw": "^2.3.5",
     "msw-storybook-addon": "^2.0.3",
-    "openapi-typescript-codegen": "^0.29.0",
     "prettier": "^3.2.5",
     "storybook": "^8.2.8",
     "typescript": "^5.8.2",
@@ -96,7 +96,7 @@
     "serve": "vite preview",
     "lint": "eslint src",
     "format": "prettier --write ./src",
-    "generate-client": "openapi --input http://localhost:8888/openapi.json --output ./src/lib/api-client --client fetch --name ApiClient --useOptions",
+    "generate-client": "openapi-ts --input http://localhost:8888/openapi.json --output ./src/lib/api-client --client fetch --name ApiClient --useOptions",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test-storybook": "test-storybook --browsers firefox webkit chromium"

--- a/frontend/src/lib/api-client/ApiClient.ts
+++ b/frontend/src/lib/api-client/ApiClient.ts
@@ -1,31 +1,33 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
 import type { BaseHttpRequest } from './core/BaseHttpRequest';
 import type { OpenAPIConfig } from './core/OpenAPI';
 import { FetchHttpRequest } from './core/FetchHttpRequest';
+
 import { AttributesService } from './services/AttributesService';
 import { FeaturesService } from './services/FeaturesService';
-type HttpRequestConstructor = new (config: OpenAPIConfig) => BaseHttpRequest;
-export class ApiClient {
-    public readonly attributes: AttributesService;
-    public readonly features: FeaturesService;
-    public readonly request: BaseHttpRequest;
-    constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = FetchHttpRequest) {
-        this.request = new HttpRequest({
-            BASE: config?.BASE ?? '',
-            VERSION: config?.VERSION ?? '0.1.0',
-            WITH_CREDENTIALS: config?.WITH_CREDENTIALS ?? false,
-            CREDENTIALS: config?.CREDENTIALS ?? 'include',
-            TOKEN: config?.TOKEN,
-            USERNAME: config?.USERNAME,
-            PASSWORD: config?.PASSWORD,
-            HEADERS: config?.HEADERS,
-            ENCODE_PATH: config?.ENCODE_PATH,
-        });
-        this.attributes = new AttributesService(this.request);
-        this.features = new FeaturesService(this.request);
-    }
-}
 
+type HttpRequestConstructor = new (config: OpenAPIConfig) => BaseHttpRequest;
+
+export class ApiClient {
+
+	public readonly attributes: AttributesService;
+	public readonly features: FeaturesService;
+
+	public readonly request: BaseHttpRequest;
+
+	constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = FetchHttpRequest) {
+		this.request = new HttpRequest({
+			BASE: config?.BASE ?? '',
+			VERSION: config?.VERSION ?? '0.1.0',
+			WITH_CREDENTIALS: config?.WITH_CREDENTIALS ?? false,
+			CREDENTIALS: config?.CREDENTIALS ?? 'include',
+			TOKEN: config?.TOKEN,
+			USERNAME: config?.USERNAME,
+			PASSWORD: config?.PASSWORD,
+			HEADERS: config?.HEADERS,
+			ENCODE_PATH: config?.ENCODE_PATH,
+		});
+
+		this.attributes = new AttributesService(this.request);
+		this.features = new FeaturesService(this.request);
+	}
+}

--- a/frontend/src/lib/api-client/core/ApiError.ts
+++ b/frontend/src/lib/api-client/core/ApiError.ts
@@ -1,25 +1,21 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
 import type { ApiRequestOptions } from './ApiRequestOptions';
 import type { ApiResult } from './ApiResult';
 
 export class ApiError extends Error {
-    public readonly url: string;
-    public readonly status: number;
-    public readonly statusText: string;
-    public readonly body: any;
-    public readonly request: ApiRequestOptions;
+	public readonly url: string;
+	public readonly status: number;
+	public readonly statusText: string;
+	public readonly body: unknown;
+	public readonly request: ApiRequestOptions;
 
-    constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
-        super(message);
+	constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
+		super(message);
 
-        this.name = 'ApiError';
-        this.url = response.url;
-        this.status = response.status;
-        this.statusText = response.statusText;
-        this.body = response.body;
-        this.request = request;
-    }
+		this.name = 'ApiError';
+		this.url = response.url;
+		this.status = response.status;
+		this.statusText = response.statusText;
+		this.body = response.body;
+		this.request = request;
+	}
 }

--- a/frontend/src/lib/api-client/core/ApiRequestOptions.ts
+++ b/frontend/src/lib/api-client/core/ApiRequestOptions.ts
@@ -1,17 +1,13 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
 export type ApiRequestOptions = {
-    readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
-    readonly url: string;
-    readonly path?: Record<string, any>;
-    readonly cookies?: Record<string, any>;
-    readonly headers?: Record<string, any>;
-    readonly query?: Record<string, any>;
-    readonly formData?: Record<string, any>;
-    readonly body?: any;
-    readonly mediaType?: string;
-    readonly responseHeader?: string;
-    readonly errors?: Record<number, string>;
+	readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
+	readonly url: string;
+	readonly path?: Record<string, unknown>;
+	readonly cookies?: Record<string, unknown>;
+	readonly headers?: Record<string, unknown>;
+	readonly query?: Record<string, unknown>;
+	readonly formData?: Record<string, unknown>;
+	readonly body?: any;
+	readonly mediaType?: string;
+	readonly responseHeader?: string;
+	readonly errors?: Record<number, string>;
 };

--- a/frontend/src/lib/api-client/core/ApiResult.ts
+++ b/frontend/src/lib/api-client/core/ApiResult.ts
@@ -1,11 +1,7 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
-export type ApiResult = {
-    readonly url: string;
-    readonly ok: boolean;
-    readonly status: number;
-    readonly statusText: string;
-    readonly body: any;
+export type ApiResult<TData = any> = {
+	readonly body: TData;
+	readonly ok: boolean;
+	readonly status: number;
+	readonly statusText: string;
+	readonly url: string;
 };

--- a/frontend/src/lib/api-client/core/BaseHttpRequest.ts
+++ b/frontend/src/lib/api-client/core/BaseHttpRequest.ts
@@ -1,14 +1,10 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
 import type { ApiRequestOptions } from './ApiRequestOptions';
 import type { CancelablePromise } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
 
 export abstract class BaseHttpRequest {
 
-    constructor(public readonly config: OpenAPIConfig) {}
+	constructor(public readonly config: OpenAPIConfig) {}
 
-    public abstract request<T>(options: ApiRequestOptions): CancelablePromise<T>;
+	public abstract request<T>(options: ApiRequestOptions): CancelablePromise<T>;
 }

--- a/frontend/src/lib/api-client/core/CancelablePromise.ts
+++ b/frontend/src/lib/api-client/core/CancelablePromise.ts
@@ -1,131 +1,127 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
 export class CancelError extends Error {
 
-    constructor(message: string) {
-        super(message);
-        this.name = 'CancelError';
-    }
+	constructor(message: string) {
+		super(message);
+		this.name = 'CancelError';
+	}
 
-    public get isCancelled(): boolean {
-        return true;
-    }
+	public get isCancelled(): boolean {
+		return true;
+	}
 }
 
 export interface OnCancel {
-    readonly isResolved: boolean;
-    readonly isRejected: boolean;
-    readonly isCancelled: boolean;
+	readonly isResolved: boolean;
+	readonly isRejected: boolean;
+	readonly isCancelled: boolean;
 
-    (cancelHandler: () => void): void;
+	(cancelHandler: () => void): void;
 }
 
 export class CancelablePromise<T> implements Promise<T> {
-    #isResolved: boolean;
-    #isRejected: boolean;
-    #isCancelled: boolean;
-    readonly #cancelHandlers: (() => void)[];
-    readonly #promise: Promise<T>;
-    #resolve?: (value: T | PromiseLike<T>) => void;
-    #reject?: (reason?: any) => void;
+	#isResolved: boolean;
+	#isRejected: boolean;
+	#isCancelled: boolean;
+	readonly #cancelHandlers: (() => void)[];
+	readonly #promise: Promise<T>;
+	#resolve?: (value: T | PromiseLike<T>) => void;
+	#reject?: (reason?: unknown) => void;
 
-    constructor(
-        executor: (
-            resolve: (value: T | PromiseLike<T>) => void,
-            reject: (reason?: any) => void,
-            onCancel: OnCancel
-        ) => void
-    ) {
-        this.#isResolved = false;
-        this.#isRejected = false;
-        this.#isCancelled = false;
-        this.#cancelHandlers = [];
-        this.#promise = new Promise<T>((resolve, reject) => {
-            this.#resolve = resolve;
-            this.#reject = reject;
+	constructor(
+		executor: (
+			resolve: (value: T | PromiseLike<T>) => void,
+			reject: (reason?: unknown) => void,
+			onCancel: OnCancel
+		) => void
+	) {
+		this.#isResolved = false;
+		this.#isRejected = false;
+		this.#isCancelled = false;
+		this.#cancelHandlers = [];
+		this.#promise = new Promise<T>((resolve, reject) => {
+			this.#resolve = resolve;
+			this.#reject = reject;
 
-            const onResolve = (value: T | PromiseLike<T>): void => {
-                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
-                    return;
-                }
-                this.#isResolved = true;
-                if (this.#resolve) this.#resolve(value);
-            };
+			const onResolve = (value: T | PromiseLike<T>): void => {
+				if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+					return;
+				}
+				this.#isResolved = true;
+				if (this.#resolve) this.#resolve(value);
+			};
 
-            const onReject = (reason?: any): void => {
-                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
-                    return;
-                }
-                this.#isRejected = true;
-                if (this.#reject) this.#reject(reason);
-            };
+			const onReject = (reason?: unknown): void => {
+				if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+					return;
+				}
+				this.#isRejected = true;
+				if (this.#reject) this.#reject(reason);
+			};
 
-            const onCancel = (cancelHandler: () => void): void => {
-                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
-                    return;
-                }
-                this.#cancelHandlers.push(cancelHandler);
-            };
+			const onCancel = (cancelHandler: () => void): void => {
+				if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+					return;
+				}
+				this.#cancelHandlers.push(cancelHandler);
+			};
 
-            Object.defineProperty(onCancel, 'isResolved', {
-                get: (): boolean => this.#isResolved,
-            });
+			Object.defineProperty(onCancel, 'isResolved', {
+				get: (): boolean => this.#isResolved,
+			});
 
-            Object.defineProperty(onCancel, 'isRejected', {
-                get: (): boolean => this.#isRejected,
-            });
+			Object.defineProperty(onCancel, 'isRejected', {
+				get: (): boolean => this.#isRejected,
+			});
 
-            Object.defineProperty(onCancel, 'isCancelled', {
-                get: (): boolean => this.#isCancelled,
-            });
+			Object.defineProperty(onCancel, 'isCancelled', {
+				get: (): boolean => this.#isCancelled,
+			});
 
-            return executor(onResolve, onReject, onCancel as OnCancel);
-        });
-    }
+			return executor(onResolve, onReject, onCancel as OnCancel);
+		});
+	}
 
-    get [Symbol.toStringTag]() {
-        return "Cancellable Promise";
-    }
+	get [Symbol.toStringTag]() {
+		return "Cancellable Promise";
+	}
 
-    public then<TResult1 = T, TResult2 = never>(
-        onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
-        onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
-    ): Promise<TResult1 | TResult2> {
-        return this.#promise.then(onFulfilled, onRejected);
-    }
+	public then<TResult1 = T, TResult2 = never>(
+		onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+		onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+	): Promise<TResult1 | TResult2> {
+		return this.#promise.then(onFulfilled, onRejected);
+	}
 
-    public catch<TResult = never>(
-        onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
-    ): Promise<T | TResult> {
-        return this.#promise.catch(onRejected);
-    }
+	public catch<TResult = never>(
+		onRejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | null
+	): Promise<T | TResult> {
+		return this.#promise.catch(onRejected);
+	}
 
-    public finally(onFinally?: (() => void) | null): Promise<T> {
-        return this.#promise.finally(onFinally);
-    }
+	public finally(onFinally?: (() => void) | null): Promise<T> {
+		return this.#promise.finally(onFinally);
+	}
 
-    public cancel(): void {
-        if (this.#isResolved || this.#isRejected || this.#isCancelled) {
-            return;
-        }
-        this.#isCancelled = true;
-        if (this.#cancelHandlers.length) {
-            try {
-                for (const cancelHandler of this.#cancelHandlers) {
-                    cancelHandler();
-                }
-            } catch (error) {
-                console.warn('Cancellation threw an error', error);
-                return;
-            }
-        }
-        this.#cancelHandlers.length = 0;
-        if (this.#reject) this.#reject(new CancelError('Request aborted'));
-    }
+	public cancel(): void {
+		if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+			return;
+		}
+		this.#isCancelled = true;
+		if (this.#cancelHandlers.length) {
+			try {
+				for (const cancelHandler of this.#cancelHandlers) {
+					cancelHandler();
+				}
+			} catch (error) {
+				console.warn('Cancellation threw an error', error);
+				return;
+			}
+		}
+		this.#cancelHandlers.length = 0;
+		if (this.#reject) this.#reject(new CancelError('Request aborted'));
+	}
 
-    public get isCancelled(): boolean {
-        return this.#isCancelled;
-    }
+	public get isCancelled(): boolean {
+		return this.#isCancelled;
+	}
 }

--- a/frontend/src/lib/api-client/core/FetchHttpRequest.ts
+++ b/frontend/src/lib/api-client/core/FetchHttpRequest.ts
@@ -1,7 +1,3 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
 import type { ApiRequestOptions } from './ApiRequestOptions';
 import { BaseHttpRequest } from './BaseHttpRequest';
 import type { CancelablePromise } from './CancelablePromise';
@@ -10,17 +6,17 @@ import { request as __request } from './request';
 
 export class FetchHttpRequest extends BaseHttpRequest {
 
-    constructor(config: OpenAPIConfig) {
-        super(config);
-    }
+	constructor(config: OpenAPIConfig) {
+		super(config);
+	}
 
-    /**
-     * Request method
-     * @param options The request options from the service
-     * @returns CancelablePromise<T>
-     * @throws ApiError
-     */
-    public override request<T>(options: ApiRequestOptions): CancelablePromise<T> {
-        return __request(this.config, options);
-    }
+	/**
+	 * Request method
+	 * @param options The request options from the service
+	 * @returns CancelablePromise<T>
+	 * @throws ApiError
+	 */
+	public override request<T>(options: ApiRequestOptions): CancelablePromise<T> {
+		return __request(this.config, options);
+	}
 }

--- a/frontend/src/lib/api-client/core/OpenAPI.ts
+++ b/frontend/src/lib/api-client/core/OpenAPI.ts
@@ -1,32 +1,45 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
 import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { TConfig, TResult } from './types';
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 type Headers = Record<string, string>;
 
 export type OpenAPIConfig = {
-    BASE: string;
-    VERSION: string;
-    WITH_CREDENTIALS: boolean;
-    CREDENTIALS: 'include' | 'omit' | 'same-origin';
-    TOKEN?: string | Resolver<string> | undefined;
-    USERNAME?: string | Resolver<string> | undefined;
-    PASSWORD?: string | Resolver<string> | undefined;
-    HEADERS?: Headers | Resolver<Headers> | undefined;
-    ENCODE_PATH?: ((path: string) => string) | undefined;
+	BASE: string;
+	CREDENTIALS: 'include' | 'omit' | 'same-origin';
+	ENCODE_PATH?: ((path: string) => string) | undefined;
+	HEADERS?: Headers | Resolver<Headers> | undefined;
+	PASSWORD?: string | Resolver<string> | undefined;
+	RESULT?: TResult;
+	TOKEN?: string | Resolver<string> | undefined;
+	USERNAME?: string | Resolver<string> | undefined;
+	VERSION: string;
+	WITH_CREDENTIALS: boolean;
 };
 
 export const OpenAPI: OpenAPIConfig = {
-    BASE: '',
-    VERSION: '0.1.0',
-    WITH_CREDENTIALS: false,
-    CREDENTIALS: 'include',
-    TOKEN: undefined,
-    USERNAME: undefined,
-    PASSWORD: undefined,
-    HEADERS: undefined,
-    ENCODE_PATH: undefined,
+	BASE: '',
+	CREDENTIALS: 'include',
+	ENCODE_PATH: undefined,
+	HEADERS: undefined,
+	PASSWORD: undefined,
+	RESULT: 'body',
+	TOKEN: undefined,
+	USERNAME: undefined,
+	VERSION: '0.1.0',
+	WITH_CREDENTIALS: false,
+};
+
+export const mergeOpenApiConfig = <T extends TResult>(config: OpenAPIConfig, overrides: TConfig<T>) => {
+	const merged = { ...config };
+	Object.entries(overrides)
+		.filter(([key]) => key.startsWith('_'))
+		.forEach(([key, value]) => {
+			const k = key.slice(1).toLocaleUpperCase() as keyof typeof merged;
+			if (merged.hasOwnProperty(k)) {
+				// @ts-ignore
+				merged[k] = value;
+			}
+		});
+	return merged;
 };

--- a/frontend/src/lib/api-client/core/request.ts
+++ b/frontend/src/lib/api-client/core/request.ts
@@ -1,7 +1,3 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
 import { ApiError } from './ApiError';
 import type { ApiRequestOptions } from './ApiRequestOptions';
 import type { ApiResult } from './ApiResult';
@@ -9,278 +5,269 @@ import { CancelablePromise } from './CancelablePromise';
 import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
 
-export const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
-    return value !== undefined && value !== null;
+export const isString = (value: unknown): value is string => {
+	return typeof value === 'string';
 };
 
-export const isString = (value: any): value is string => {
-    return typeof value === 'string';
-};
-
-export const isStringWithValue = (value: any): value is string => {
-    return isString(value) && value !== '';
+export const isStringWithValue = (value: unknown): value is string => {
+	return isString(value) && value !== '';
 };
 
 export const isBlob = (value: any): value is Blob => {
-    return (
-        typeof value === 'object' &&
-        typeof value.type === 'string' &&
-        typeof value.stream === 'function' &&
-        typeof value.arrayBuffer === 'function' &&
-        typeof value.constructor === 'function' &&
-        typeof value.constructor.name === 'string' &&
-        /^(Blob|File)$/.test(value.constructor.name) &&
-        /^(Blob|File)$/.test(value[Symbol.toStringTag])
-    );
+	return (
+		value !== null &&
+		typeof value === 'object' &&
+		typeof value.type === 'string' &&
+		typeof value.stream === 'function' &&
+		typeof value.arrayBuffer === 'function' &&
+		typeof value.constructor === 'function' &&
+		typeof value.constructor.name === 'string' &&
+		/^(Blob|File)$/.test(value.constructor.name) &&
+		// @ts-ignore
+		/^(Blob|File)$/.test(value[Symbol.toStringTag])
+	);
 };
 
-export const isFormData = (value: any): value is FormData => {
-    return value instanceof FormData;
+export const isFormData = (value: unknown): value is FormData => {
+	return value instanceof FormData;
 };
 
 export const base64 = (str: string): string => {
-    try {
-        return btoa(str);
-    } catch (err) {
-        // @ts-ignore
-        return Buffer.from(str).toString('base64');
-    }
+	try {
+		return btoa(str);
+	} catch (err) {
+		// @ts-ignore
+		return Buffer.from(str).toString('base64');
+	}
 };
 
-export const getQueryString = (params: Record<string, any>): string => {
-    const qs: string[] = [];
+export const getQueryString = (params: Record<string, unknown>): string => {
+	const qs: string[] = [];
 
-    const append = (key: string, value: any) => {
-        qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
-    };
+	const append = (key: string, value: unknown) => {
+		qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+	};
 
-    const process = (key: string, value: any) => {
-        if (isDefined(value)) {
-            if (Array.isArray(value)) {
-                value.forEach(v => {
-                    process(key, v);
-                });
-            } else if (typeof value === 'object') {
-                Object.entries(value).forEach(([k, v]) => {
-                    process(`${key}[${k}]`, v);
-                });
-            } else {
-                append(key, value);
-            }
-        }
-    };
+	const encodePair = (key: string, value: unknown) => {
+		if (value === undefined || value === null) {
+			return;
+		}
 
-    Object.entries(params).forEach(([key, value]) => {
-        process(key, value);
-    });
+		if (Array.isArray(value)) {
+			value.forEach(v => encodePair(key, v));
+		} else if (typeof value === 'object') {
+			Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v));
+		} else {
+			append(key, value);
+		}
+	};
 
-    if (qs.length > 0) {
-        return `?${qs.join('&')}`;
-    }
+	Object.entries(params).forEach(([key, value]) => encodePair(key, value));
 
-    return '';
+	return qs.length ? `?${qs.join('&')}` : '';
 };
 
 const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
-    const encoder = config.ENCODE_PATH || encodeURI;
+	const encoder = config.ENCODE_PATH || encodeURI;
 
-    const path = options.url
-        .replace('{api-version}', config.VERSION)
-        .replace(/{(.*?)}/g, (substring: string, group: string) => {
-            if (options.path?.hasOwnProperty(group)) {
-                return encoder(String(options.path[group]));
-            }
-            return substring;
-        });
+	const path = options.url
+		.replace('{api-version}', config.VERSION)
+		.replace(/{(.*?)}/g, (substring: string, group: string) => {
+			if (options.path?.hasOwnProperty(group)) {
+				return encoder(String(options.path[group]));
+			}
+			return substring;
+		});
 
-    const url = `${config.BASE}${path}`;
-    if (options.query) {
-        return `${url}${getQueryString(options.query)}`;
-    }
-    return url;
+	const url = config.BASE + path;
+	return options.query ? url + getQueryString(options.query) : url;
 };
 
 export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
-    if (options.formData) {
-        const formData = new FormData();
+	if (options.formData) {
+		const formData = new FormData();
 
-        const process = (key: string, value: any) => {
-            if (isString(value) || isBlob(value)) {
-                formData.append(key, value);
-            } else {
-                formData.append(key, JSON.stringify(value));
-            }
-        };
+		const process = (key: string, value: any) => {
+			if (isString(value) || isBlob(value)) {
+				formData.append(key, value);
+			} else {
+				formData.append(key, JSON.stringify(value));
+			}
+		};
 
-        Object.entries(options.formData)
-            .filter(([_, value]) => isDefined(value))
-            .forEach(([key, value]) => {
-                if (Array.isArray(value)) {
-                    value.forEach(v => process(key, v));
-                } else {
-                    process(key, value);
-                }
-            });
+		Object.entries(options.formData)
+			.filter(([_, value]) => value !== undefined && value !== null)
+			.forEach(([key, value]) => {
+				if (Array.isArray(value)) {
+					value.forEach(v => process(key, v));
+				} else {
+					process(key, value);
+				}
+			});
 
-        return formData;
-    }
-    return undefined;
+		return formData;
+	}
+	return undefined;
 };
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 
 export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
-    if (typeof resolver === 'function') {
-        return (resolver as Resolver<T>)(options);
-    }
-    return resolver;
+	if (typeof resolver === 'function') {
+		return (resolver as Resolver<T>)(options);
+	}
+	return resolver;
 };
 
 export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
-    const [token, username, password, additionalHeaders] = await Promise.all([
-        resolve(options, config.TOKEN),
-        resolve(options, config.USERNAME),
-        resolve(options, config.PASSWORD),
-        resolve(options, config.HEADERS),
-    ]);
+	const [token, username, password, additionalHeaders] = await Promise.all([
+		resolve(options, config.TOKEN),
+		resolve(options, config.USERNAME),
+		resolve(options, config.PASSWORD),
+		resolve(options, config.HEADERS),
+	]);
 
-    const headers = Object.entries({
-        Accept: 'application/json',
-        ...additionalHeaders,
-        ...options.headers,
-    })
-        .filter(([_, value]) => isDefined(value))
-        .reduce((headers, [key, value]) => ({
-            ...headers,
-            [key]: String(value),
-        }), {} as Record<string, string>);
+	const headers = Object.entries({
+		Accept: 'application/json',
+		...additionalHeaders,
+		...options.headers,
+	})
+		.filter(([_, value]) => value !== undefined && value !== null)
+		.reduce((headers, [key, value]) => ({
+			...headers,
+			[key]: String(value),
+		}), {} as Record<string, string>);
 
-    if (isStringWithValue(token)) {
-        headers['Authorization'] = `Bearer ${token}`;
-    }
+	if (isStringWithValue(token)) {
+		headers['Authorization'] = `Bearer ${token}`;
+	}
 
-    if (isStringWithValue(username) && isStringWithValue(password)) {
-        const credentials = base64(`${username}:${password}`);
-        headers['Authorization'] = `Basic ${credentials}`;
-    }
+	if (isStringWithValue(username) && isStringWithValue(password)) {
+		const credentials = base64(`${username}:${password}`);
+		headers['Authorization'] = `Basic ${credentials}`;
+	}
 
-    if (options.body !== undefined) {
-        if (options.mediaType) {
-            headers['Content-Type'] = options.mediaType;
-        } else if (isBlob(options.body)) {
-            headers['Content-Type'] = options.body.type || 'application/octet-stream';
-        } else if (isString(options.body)) {
-            headers['Content-Type'] = 'text/plain';
-        } else if (!isFormData(options.body)) {
-            headers['Content-Type'] = 'application/json';
-        }
-    }
+	if (options.body !== undefined) {
+		if (options.mediaType) {
+			headers['Content-Type'] = options.mediaType;
+		} else if (isBlob(options.body)) {
+			headers['Content-Type'] = options.body.type || 'application/octet-stream';
+		} else if (isString(options.body)) {
+			headers['Content-Type'] = 'text/plain';
+		} else if (!isFormData(options.body)) {
+			headers['Content-Type'] = 'application/json';
+		}
+	}
 
-    return new Headers(headers);
+	return new Headers(headers);
 };
 
-export const getRequestBody = (options: ApiRequestOptions): any => {
-    if (options.body !== undefined) {
-        if (options.mediaType?.includes('/json')) {
-            return JSON.stringify(options.body)
-        } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
-            return options.body;
-        } else {
-            return JSON.stringify(options.body);
-        }
-    }
-    return undefined;
+export const getRequestBody = (options: ApiRequestOptions): unknown => {
+	if (options.body !== undefined) {
+		if (options.mediaType?.includes('/json')) {
+			return JSON.stringify(options.body)
+		} else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
+			return options.body;
+		} else {
+			return JSON.stringify(options.body);
+		}
+	}
+	return undefined;
 };
 
 export const sendRequest = async (
-    config: OpenAPIConfig,
-    options: ApiRequestOptions,
-    url: string,
-    body: any,
-    formData: FormData | undefined,
-    headers: Headers,
-    onCancel: OnCancel
+	config: OpenAPIConfig,
+	options: ApiRequestOptions,
+	url: string,
+	body: any,
+	formData: FormData | undefined,
+	headers: Headers,
+	onCancel: OnCancel
 ): Promise<Response> => {
-    const controller = new AbortController();
+	const controller = new AbortController();
 
-    const request: RequestInit = {
-        headers,
-        body: body ?? formData,
-        method: options.method,
-        signal: controller.signal,
-    };
+	const request: RequestInit = {
+		headers,
+		body: body ?? formData,
+		method: options.method,
+		signal: controller.signal,
+	};
 
-    if (config.WITH_CREDENTIALS) {
-        request.credentials = config.CREDENTIALS;
-    }
+	if (config.WITH_CREDENTIALS) {
+		request.credentials = config.CREDENTIALS;
+	}
 
-    onCancel(() => controller.abort());
+	onCancel(() => controller.abort());
 
-    return await fetch(url, request);
+	return await fetch(url, request);
 };
 
 export const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
-    if (responseHeader) {
-        const content = response.headers.get(responseHeader);
-        if (isString(content)) {
-            return content;
-        }
-    }
-    return undefined;
+	if (responseHeader) {
+		const content = response.headers.get(responseHeader);
+		if (isString(content)) {
+			return content;
+		}
+	}
+	return undefined;
 };
 
-export const getResponseBody = async (response: Response): Promise<any> => {
-    if (response.status !== 204) {
-        try {
-            const contentType = response.headers.get('Content-Type');
-            if (contentType) {
-                const jsonTypes = ['application/json', 'application/problem+json']
-                const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
-                if (isJSON) {
-                    return await response.json();
-                } else {
-                    return await response.text();
-                }
-            }
-        } catch (error) {
-            console.error(error);
-        }
-    }
-    return undefined;
+export const getResponseBody = async (response: Response): Promise<unknown> => {
+	if (response.status !== 204) {
+		try {
+			const contentType = response.headers.get('Content-Type');
+			if (contentType) {
+				const jsonTypes = ['application/json', 'application/problem+json'];
+				const binaryTypes = ['audio/', 'image/', 'video/'];
+				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
+                const isBinary = binaryTypes.some(type => contentType.toLowerCase().startsWith(type));
+				if (isJSON) {
+					return await response.json();
+				} else if (isBinary) {
+					return await response.blob();
+				} else {
+					return await response.text();
+				}
+			}
+		} catch (error) {
+			console.error(error);
+		}
+	}
+	return undefined;
 };
 
 export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
-    const errors: Record<number, string> = {
-        400: 'Bad Request',
-        401: 'Unauthorized',
-        403: 'Forbidden',
-        404: 'Not Found',
-        500: 'Internal Server Error',
-        502: 'Bad Gateway',
-        503: 'Service Unavailable',
-        ...options.errors,
-    }
+	const errors: Record<number, string> = {
+		400: 'Bad Request',
+		401: 'Unauthorized',
+		403: 'Forbidden',
+		404: 'Not Found',
+		500: 'Internal Server Error',
+		502: 'Bad Gateway',
+		503: 'Service Unavailable',
+		...options.errors,
+	}
 
-    const error = errors[result.status];
-    if (error) {
-        throw new ApiError(options, result, error);
-    }
+	const error = errors[result.status];
+	if (error) {
+		throw new ApiError(options, result, error);
+	}
 
-    if (!result.ok) {
-        const errorStatus = result.status ?? 'unknown';
-        const errorStatusText = result.statusText ?? 'unknown';
-        const errorBody = (() => {
-            try {
-                return JSON.stringify(result.body, null, 2);
-            } catch (e) {
-                return undefined;
-            }
-        })();
+	if (!result.ok) {
+		const errorStatus = result.status ?? 'unknown';
+		const errorStatusText = result.statusText ?? 'unknown';
+		const errorBody = (() => {
+			try {
+				return JSON.stringify(result.body, null, 2);
+			} catch (e) {
+				return undefined;
+			}
+		})();
 
-        throw new ApiError(options, result,
-            `Generic Error: status: ${errorStatus}; status text: ${errorStatusText}; body: ${errorBody}`
-        );
-    }
+		throw new ApiError(options, result,
+			`Generic Error: status: ${errorStatus}; status text: ${errorStatusText}; body: ${errorBody}`
+		);
+	}
 };
 
 /**
@@ -291,32 +278,32 @@ export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): 
  * @throws ApiError
  */
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
-    return new CancelablePromise(async (resolve, reject, onCancel) => {
-        try {
-            const url = getUrl(config, options);
-            const formData = getFormData(options);
-            const body = getRequestBody(options);
-            const headers = await getHeaders(config, options);
+	return new CancelablePromise(async (resolve, reject, onCancel) => {
+		try {
+			const url = getUrl(config, options);
+			const formData = getFormData(options);
+			const body = getRequestBody(options);
+			const headers = await getHeaders(config, options);
 
-            if (!onCancel.isCancelled) {
-                const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
-                const responseBody = await getResponseBody(response);
-                const responseHeader = getResponseHeader(response, options.responseHeader);
+			if (!onCancel.isCancelled) {
+				const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
+				const responseBody = await getResponseBody(response);
+				const responseHeader = getResponseHeader(response, options.responseHeader);
 
-                const result: ApiResult = {
-                    url,
-                    ok: response.ok,
-                    status: response.status,
-                    statusText: response.statusText,
-                    body: responseHeader ?? responseBody,
-                };
+				const result: ApiResult = {
+					url,
+					ok: response.ok,
+					status: response.status,
+					statusText: response.statusText,
+					body: responseHeader ?? responseBody,
+				};
 
-                catchErrorCodes(options, result);
+				catchErrorCodes(options, result);
 
-                resolve(result.body);
-            }
-        } catch (error) {
-            reject(error);
-        }
-    });
+				resolve(result.body);
+			}
+		} catch (error) {
+			reject(error);
+		}
+	});
 };

--- a/frontend/src/lib/api-client/core/types.ts
+++ b/frontend/src/lib/api-client/core/types.ts
@@ -1,0 +1,12 @@
+import type { ApiResult } from './ApiResult';
+
+export type TResult = 'body' | 'raw';
+
+export type TApiResponse<T extends TResult, TData> =
+  Exclude<T, 'raw'> extends never
+    ? ApiResult<TData>
+    : ApiResult<TData>['body'];
+
+export type TConfig<T extends TResult> = {
+  _result?: T;
+};

--- a/frontend/src/lib/api-client/index.ts
+++ b/frontend/src/lib/api-client/index.ts
@@ -1,7 +1,3 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
 export { ApiClient } from './ApiClient';
 
 export { ApiError } from './core/ApiError';
@@ -10,16 +6,6 @@ export { CancelablePromise, CancelError } from './core/CancelablePromise';
 export { OpenAPI } from './core/OpenAPI';
 export type { OpenAPIConfig } from './core/OpenAPI';
 
-export type { Adaptation } from './models/Adaptation';
-export type { ExpectedDamage } from './models/ExpectedDamage';
-export type { FeatureListItemOut_float_ } from './models/FeatureListItemOut_float_';
-export type { FeatureOut } from './models/FeatureOut';
-export type { HTTPValidationError } from './models/HTTPValidationError';
-export type { NPVDamage } from './models/NPVDamage';
-export type { Page_FeatureListItemOut_float__ } from './models/Page_FeatureListItemOut_float__';
-export type { ProtectedFeatureListItem } from './models/ProtectedFeatureListItem';
-export type { ReturnPeriodDamage } from './models/ReturnPeriodDamage';
-export type { ValidationError } from './models/ValidationError';
-
-export { AttributesService } from './services/AttributesService';
-export { FeaturesService } from './services/FeaturesService';
+export * from './models'
+export * from './schemas'
+export * from './services'

--- a/frontend/src/lib/api-client/models/Adaptation.ts
+++ b/frontend/src/lib/api-client/models/Adaptation.ts
@@ -1,18 +1,16 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
+
+
 export type Adaptation = {
-    adaptation_cost: number;
-    avoided_ead_amin: number;
-    avoided_ead_mean: number;
-    avoided_ead_amax: number;
-    avoided_eael_amin: number;
-    avoided_eael_mean: number;
-    avoided_eael_amax: number;
-    hazard: string;
-    rcp: string;
-    adaptation_name: string;
-    adaptation_protection_level: number;
+	adaptation_cost: number;
+	avoided_ead_amin: number;
+	avoided_ead_mean: number;
+	avoided_ead_amax: number;
+	avoided_eael_amin: number;
+	avoided_eael_mean: number;
+	avoided_eael_amax: number;
+	hazard: string;
+	rcp: string;
+	adaptation_name: string;
+	adaptation_protection_level: number;
 };
 

--- a/frontend/src/lib/api-client/models/ExpectedDamage.ts
+++ b/frontend/src/lib/api-client/models/ExpectedDamage.ts
@@ -1,17 +1,15 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
+
+
 export type ExpectedDamage = {
-    ead_amin: number;
-    ead_mean: number;
-    ead_amax: number;
-    eael_amin: number;
-    eael_mean: number;
-    eael_amax: number;
-    hazard: string;
-    rcp: string;
-    epoch: (string | number);
-    protection_standard: number;
+	ead_amin: number;
+	ead_mean: number;
+	ead_amax: number;
+	eael_amin: number;
+	eael_mean: number;
+	eael_amax: number;
+	hazard: string;
+	rcp: string;
+	epoch: string | number;
+	protection_standard: number;
 };
 

--- a/frontend/src/lib/api-client/models/FeatureListItemOut_float_.ts
+++ b/frontend/src/lib/api-client/models/FeatureListItemOut_float_.ts
@@ -1,12 +1,10 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
+
+
 export type FeatureListItemOut_float_ = {
-    id: number;
-    string_id: string;
-    layer: string;
-    bbox_wkt: string;
-    value: number;
+	id: number;
+	string_id: string;
+	layer: string;
+	bbox_wkt: string;
+	value: number;
 };
 

--- a/frontend/src/lib/api-client/models/FeatureOut.ts
+++ b/frontend/src/lib/api-client/models/FeatureOut.ts
@@ -1,20 +1,17 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
 import type { Adaptation } from './Adaptation';
 import type { ExpectedDamage } from './ExpectedDamage';
 import type { NPVDamage } from './NPVDamage';
 import type { ReturnPeriodDamage } from './ReturnPeriodDamage';
+
 export type FeatureOut = {
-    id: number;
-    string_id: string;
-    layer: string;
-    sublayer?: (string | null);
-    properties: Record<string, any>;
-    damages_expected?: Array<ExpectedDamage>;
-    damages_return_period?: Array<ReturnPeriodDamage>;
-    damages_npv?: Array<NPVDamage>;
-    adaptation?: Array<Adaptation>;
+	id: number;
+	string_id: string;
+	layer: string;
+	sublayer?: string | null;
+	properties: Record<string, unknown>;
+	damages_expected?: Array<ExpectedDamage>;
+	damages_return_period?: Array<ReturnPeriodDamage>;
+	damages_npv?: Array<NPVDamage>;
+	adaptation?: Array<Adaptation>;
 };
 

--- a/frontend/src/lib/api-client/models/HTTPValidationError.ts
+++ b/frontend/src/lib/api-client/models/HTTPValidationError.ts
@@ -1,9 +1,6 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
 import type { ValidationError } from './ValidationError';
+
 export type HTTPValidationError = {
-    detail?: Array<ValidationError>;
+	detail?: Array<ValidationError>;
 };
 

--- a/frontend/src/lib/api-client/models/NPVDamage.ts
+++ b/frontend/src/lib/api-client/models/NPVDamage.ts
@@ -1,15 +1,13 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
+
+
 export type NPVDamage = {
-    ead_amin: number;
-    ead_mean: number;
-    ead_amax: number;
-    eael_amin: number;
-    eael_mean: number;
-    eael_amax: number;
-    hazard: string;
-    rcp: string;
+	ead_amin: number;
+	ead_mean: number;
+	ead_amax: number;
+	eael_amin: number;
+	eael_mean: number;
+	eael_amax: number;
+	hazard: string;
+	rcp: string;
 };
 

--- a/frontend/src/lib/api-client/models/Page_FeatureListItemOut_float__.ts
+++ b/frontend/src/lib/api-client/models/Page_FeatureListItemOut_float__.ts
@@ -1,13 +1,10 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
 import type { FeatureListItemOut_float_ } from './FeatureListItemOut_float_';
+
 export type Page_FeatureListItemOut_float__ = {
-    items: Array<FeatureListItemOut_float_>;
-    total: (number | null);
-    page: (number | null);
-    size: (number | null);
-    pages?: (number | null);
+	items: Array<FeatureListItemOut_float_>;
+	total: number | null;
+	page: number | null;
+	size: number | null;
+	pages?: number | null;
 };
 

--- a/frontend/src/lib/api-client/models/ProtectedFeatureListItem.ts
+++ b/frontend/src/lib/api-client/models/ProtectedFeatureListItem.ts
@@ -1,17 +1,15 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
+
+
 export type ProtectedFeatureListItem = {
-    id: number;
-    string_id: string;
-    layer: string;
-    adaptation_name: string;
-    adaptation_protection_level: number;
-    adaptation_cost: number;
-    avoided_ead_mean: number;
-    avoided_eael_mean: number;
-    hazard: string;
-    rcp: number;
+	id: number;
+	string_id: string;
+	layer: string;
+	adaptation_name: string;
+	adaptation_protection_level: number;
+	adaptation_cost: number;
+	avoided_ead_mean: number;
+	avoided_eael_mean: number;
+	hazard: string;
+	rcp: number;
 };
 

--- a/frontend/src/lib/api-client/models/ReturnPeriodDamage.ts
+++ b/frontend/src/lib/api-client/models/ReturnPeriodDamage.ts
@@ -1,18 +1,16 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
+
+
 export type ReturnPeriodDamage = {
-    exposure: number;
-    damage_amin: number;
-    damage_mean: number;
-    damage_amax: number;
-    loss_amin: number;
-    loss_mean: number;
-    loss_amax: number;
-    hazard: string;
-    rcp: string;
-    epoch: (string | number);
-    rp: number;
+	exposure: number;
+	damage_amin: number;
+	damage_mean: number;
+	damage_amax: number;
+	loss_amin: number;
+	loss_mean: number;
+	loss_amax: number;
+	hazard: string;
+	rcp: string;
+	epoch: string | number;
+	rp: number;
 };
 

--- a/frontend/src/lib/api-client/models/ValidationError.ts
+++ b/frontend/src/lib/api-client/models/ValidationError.ts
@@ -1,10 +1,8 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
+
+
 export type ValidationError = {
-    loc: Array<(string | number)>;
-    msg: string;
-    type: string;
+	loc: Array<string | number>;
+	msg: string;
+	type: string;
 };
 

--- a/frontend/src/lib/api-client/models/index.ts
+++ b/frontend/src/lib/api-client/models/index.ts
@@ -1,0 +1,10 @@
+export type { Adaptation } from './Adaptation';
+export type { ExpectedDamage } from './ExpectedDamage';
+export type { FeatureListItemOut_float_ } from './FeatureListItemOut_float_';
+export type { FeatureOut } from './FeatureOut';
+export type { HTTPValidationError } from './HTTPValidationError';
+export type { NPVDamage } from './NPVDamage';
+export type { Page_FeatureListItemOut_float__ } from './Page_FeatureListItemOut_float__';
+export type { ProtectedFeatureListItem } from './ProtectedFeatureListItem';
+export type { ReturnPeriodDamage } from './ReturnPeriodDamage';
+export type { ValidationError } from './ValidationError';

--- a/frontend/src/lib/api-client/services/AttributesService.ts
+++ b/frontend/src/lib/api-client/services/AttributesService.ts
@@ -1,48 +1,49 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
+
 import type { CancelablePromise } from '../core/CancelablePromise';
 import type { BaseHttpRequest } from '../core/BaseHttpRequest';
+
+export type TDataAttributesReadAttributes = {
+                dimensions: string
+field: string
+fieldGroup: string
+layer: string
+parameters: string
+requestBody: Array<number>
+            }
+
 export class AttributesService {
-    constructor(public readonly httpRequest: BaseHttpRequest) {}
-    /**
-     * Read Attributes
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public attributesReadAttributes({
-        fieldGroup,
-        layer,
-        field,
-        dimensions,
-        parameters,
-        requestBody,
-    }: {
-        fieldGroup: string,
-        layer: string,
-        field: string,
-        dimensions: string,
-        parameters: string,
-        requestBody: Array<number>,
-    }): CancelablePromise<Record<string, null>> {
-        return this.httpRequest.request({
-            method: 'POST',
-            url: '/attributes/{field_group}',
-            path: {
-                'field_group': fieldGroup,
-            },
-            query: {
-                'layer': layer,
-                'field': field,
-                'dimensions': dimensions,
-                'parameters': parameters,
-            },
-            body: requestBody,
-            mediaType: 'application/json',
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
+
+	constructor(public readonly httpRequest: BaseHttpRequest) {}
+
+	/**
+	 * Read Attributes
+	 * @returns unknown Successful Response
+	 * @throws ApiError
+	 */
+	public attributesReadAttributes(data: TDataAttributesReadAttributes): CancelablePromise<Record<string, unknown | null>> {
+		const {
+dimensions,
+field,
+fieldGroup,
+layer,
+parameters,
+requestBody,
+} = data;
+		return this.httpRequest.request({
+			method: 'POST',
+			url: '/attributes/{field_group}',
+			path: {
+				field_group: fieldGroup
+			},
+			query: {
+				layer, field, dimensions, parameters
+			},
+			body: requestBody,
+			mediaType: 'application/json',
+			errors: {
+				422: `Validation Error`,
+			},
+		});
+	}
+
 }

--- a/frontend/src/lib/api-client/services/FeaturesService.ts
+++ b/frontend/src/lib/api-client/services/FeaturesService.ts
@@ -1,114 +1,114 @@
-/* generated using openapi-typescript-codegen -- do not edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
 import type { FeatureOut } from '../models/FeatureOut';
 import type { Page_FeatureListItemOut_float__ } from '../models/Page_FeatureListItemOut_float__';
 import type { ProtectedFeatureListItem } from '../models/ProtectedFeatureListItem';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import type { BaseHttpRequest } from '../core/BaseHttpRequest';
+
+export type TDataFeaturesReadFeature = {
+                featureId: number
+            }
+export type TDataFeaturesReadSortedFeatures = {
+                assetType?: string | null
+dimensions: string
+field: string
+fieldGroup: string
+layer?: string | null
+page?: number
+parameters: string
+sector?: string | null
+size?: number
+subsector?: string | null
+            }
+export type TDataFeaturesReadProtectedFeatures = {
+                protectionLevel: number
+protectorId: number
+rcp: string
+            }
+
 export class FeaturesService {
-    constructor(public readonly httpRequest: BaseHttpRequest) {}
-    /**
-     * Read Feature
-     * @returns FeatureOut Successful Response
-     * @throws ApiError
-     */
-    public featuresReadFeature({
-        featureId,
-    }: {
-        featureId: number,
-    }): CancelablePromise<FeatureOut> {
-        return this.httpRequest.request({
-            method: 'GET',
-            url: '/features/{feature_id}',
-            path: {
-                'feature_id': featureId,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Read Sorted Features
-     * @returns Page_FeatureListItemOut_float__ Successful Response
-     * @throws ApiError
-     */
-    public featuresReadSortedFeatures({
-        fieldGroup,
-        field,
-        dimensions,
-        parameters,
-        layer,
-        sector,
-        subsector,
-        assetType,
-        page = 1,
-        size = 50,
-    }: {
-        fieldGroup: string,
-        field: string,
-        dimensions: string,
-        parameters: string,
-        layer?: (string | null),
-        sector?: (string | null),
-        subsector?: (string | null),
-        assetType?: (string | null),
-        page?: number,
-        size?: number,
-    }): CancelablePromise<Page_FeatureListItemOut_float__> {
-        return this.httpRequest.request({
-            method: 'GET',
-            url: '/features/sorted-by/{field_group}',
-            path: {
-                'field_group': fieldGroup,
-            },
-            query: {
-                'field': field,
-                'dimensions': dimensions,
-                'parameters': parameters,
-                'layer': layer,
-                'sector': sector,
-                'subsector': subsector,
-                'asset_type': assetType,
-                'page': page,
-                'size': size,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Read Protected Features
-     * Get all adaptation options, by feature ID and layer, for features
-     * protected by a given protector feature.
-     * @returns ProtectedFeatureListItem Successful Response
-     * @throws ApiError
-     */
-    public featuresReadProtectedFeatures({
-        protectorId,
-        rcp,
-        protectionLevel,
-    }: {
-        protectorId: number,
-        rcp: string,
-        protectionLevel: number,
-    }): CancelablePromise<Array<ProtectedFeatureListItem>> {
-        return this.httpRequest.request({
-            method: 'GET',
-            url: '/features/{protector_id}/protected-by',
-            path: {
-                'protector_id': protectorId,
-            },
-            query: {
-                'rcp': rcp,
-                'protection_level': protectionLevel,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
+
+	constructor(public readonly httpRequest: BaseHttpRequest) {}
+
+	/**
+	 * Read Feature
+	 * @returns FeatureOut Successful Response
+	 * @throws ApiError
+	 */
+	public featuresReadFeature(data: TDataFeaturesReadFeature): CancelablePromise<FeatureOut> {
+		const {
+featureId,
+} = data;
+		return this.httpRequest.request({
+			method: 'GET',
+			url: '/features/{feature_id}',
+			path: {
+				feature_id: featureId
+			},
+			errors: {
+				422: `Validation Error`,
+			},
+		});
+	}
+
+	/**
+	 * Read Sorted Features
+	 * @returns Page_FeatureListItemOut_float__ Successful Response
+	 * @throws ApiError
+	 */
+	public featuresReadSortedFeatures(data: TDataFeaturesReadSortedFeatures): CancelablePromise<Page_FeatureListItemOut_float__> {
+		const {
+assetType,
+dimensions,
+field,
+fieldGroup,
+layer,
+page = 1,
+parameters,
+sector,
+size = 50,
+subsector,
+} = data;
+		return this.httpRequest.request({
+			method: 'GET',
+			url: '/features/sorted-by/{field_group}',
+			path: {
+				field_group: fieldGroup
+			},
+			query: {
+				field, dimensions, parameters, layer, sector, subsector, asset_type: assetType, page, size
+			},
+			errors: {
+				422: `Validation Error`,
+			},
+		});
+	}
+
+	/**
+	 * Read Protected Features
+	 * Get all adaptation options, by feature ID and layer, for features
+ * protected by a given protector feature.
+	 * @returns ProtectedFeatureListItem Successful Response
+	 * @throws ApiError
+	 */
+	public featuresReadProtectedFeatures(data: TDataFeaturesReadProtectedFeatures): CancelablePromise<Array<ProtectedFeatureListItem>> {
+		const {
+protectionLevel,
+protectorId,
+rcp,
+} = data;
+		return this.httpRequest.request({
+			method: 'GET',
+			url: '/features/{protector_id}/protected-by',
+			path: {
+				protector_id: protectorId
+			},
+			query: {
+				rcp, protection_level: protectionLevel
+			},
+			errors: {
+				422: `Validation Error`,
+			},
+		});
+	}
+
 }

--- a/frontend/src/lib/api-client/services/index.ts
+++ b/frontend/src/lib/api-client/services/index.ts
@@ -1,0 +1,2 @@
+export { AttributesService } from './AttributesService'
+export { FeaturesService } from './FeaturesService'


### PR DESCRIPTION
v0.29 looks like the last version that was backwards compatible with `openapi-typescript-codegen`.

> Due to time limitations on my end, this project has been unmaintained for a while now. The @hey-api/openapi-ts project started as a fork with the goal to resolve the most pressing issues. going forward they are planning to maintain the OpenAPI generator and give it the love it deserves.

https://www.npmjs.com/package/openapi-typescript-codegen