### PR TITLE
chore(frontend): 0.4.26

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irv-jamaica",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irv-jamaica",
-      "version": "0.4.25",
+      "version": "0.4.26",
       "dependencies": {
         "@deck.gl/extensions": "^9.1.4",
         "@emotion/react": "^11.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "irv-jamaica",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Major dependency updates:
- Material UI v7.
- Migrate the API client to `@hey-api/openapi-ts` and `@hey-api/client-fetch`.
- Vega v6.
- React Router v7.