### PR TITLE
fix: zarr errors with the most recent numcodecs

### DIFF
--- a/pixel_driller/requirements.txt
+++ b/pixel_driller/requirements.txt
@@ -7,4 +7,4 @@ rasterio==1.3.9
 rioxarray==0.18.2
 tqdm==4.67.1
 xarray==2025.1.1
-zarr==2.18.3
+zarr~=2.18.3


### PR DESCRIPTION
An update to numcodecs broke zarr. Fixed in zarr 2.18.6 so I've modified `requirements.txt` to allow patches for `zarr`.