### PR TITLE
build(raster-tileserver): add requirements.txt

### DIFF
--- a/tileserver/raster/Dockerfile
+++ b/tileserver/raster/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.10
 
 RUN apt-get update && apt-get install -y libgdal-dev
 WORKDIR /code
+COPY requirements.txt requirements.txt
 RUN python -m pip install --upgrade pip setuptools wheel
-RUN pip install cython "numpy>=1.15,!=1.17.0,<1.24"
-RUN pip install gunicorn terracotta[recommended]~=0.8
+RUN pip install -r requirements.txt
 
 CMD ["gunicorn", "--workers", "3", "--bind", "0.0.0.0:5000", "-m", "007", "--access-logfile", "'-'", "terracotta.server.app:app"]

--- a/tileserver/raster/requirements.txt
+++ b/tileserver/raster/requirements.txt
@@ -1,0 +1,4 @@
+cython~=3.0.12
+terracotta~=0.8
+gunicorn
+numpy>=1.15,!=1.17.0,<1.24


### PR DESCRIPTION
Add `requirements.txt` to the raster tileserver and build the image with a specific version of Cython.

Cython 3.1 came out recently and breaks the Docker build, which relies on the deprecated `numpy/math.pxd` module.