### PR TITLE
fix(frontend): hotspot storybook state

### DIFF
--- a/frontend/src/data-layers/risks/sidebar/RisksSection.tsx
+++ b/frontend/src/data-layers/risks/sidebar/RisksSection.tsx
@@ -1,5 +1,7 @@
 import { FC } from 'react';
 
+import { useSyncConfigState } from 'app/state/data-params';
+
 import { SidebarPanel } from 'lib/sidebar/SidebarPanel';
 import { SidebarPanelSection } from 'lib/sidebar/ui/SidebarPanelSection';
 import { ErrorBoundary } from 'lib/react/ErrorBoundary';
@@ -7,6 +9,7 @@ import { ErrorBoundary } from 'lib/react/ErrorBoundary';
 import { RisksControl } from './RisksControl';
 
 export const RisksSection: FC = () => {
+  useSyncConfigState();
   return (
     <SidebarPanel id="risks" title="Hotspots">
       <ErrorBoundary message="There was a problem displaying this section.">


### PR DESCRIPTION
Add `useSyncConfigState` to the hotspots sidebar section. Fixes a bug where the hotspot menus are empty in the storybook.