### PR TITLE
fix(frontend): add > to raster tooltip values

### DIFF
--- a/frontend/src/lib/map/tooltip/content/RasterHoverDescription.tsx
+++ b/frontend/src/lib/map/tooltip/content/RasterHoverDescription.tsx
@@ -32,11 +32,13 @@ const formatter = {
   years: (value) => `${parseInt(value)} years`,
 };
 
-function formatValue(color, value, dataUnit, type) {
+function formatValue(color, value, dataUnit, type, maxValue) {
+  const formattedValue = value == null ? '' : formatter[type](value, dataUnit);
   return (
     <>
       <ColorBox color={color} />
-      {value == null ? '' : formatter[type](value, dataUnit)}
+      {value === maxValue ? '> ' : ''}
+      {formattedValue}
     </>
   );
 }
@@ -56,10 +58,11 @@ export const RasterHoverDescription: FC<{
 
   const colorString = `rgb(${color[0]},${color[1]},${color[2]})`;
   const value = rasterValueLookup?.[colorString];
+  const maxValue = range[1];
 
   return (
     <Box>
-      <DataItem label={title} value={formatValue(colorString, value, dataUnit, type)} />
+      <DataItem label={title} value={formatValue(colorString, value, dataUnit, type, maxValue)} />
     </Box>
   );
 };


### PR DESCRIPTION
Add a ">" to the raster tooltip values when the current colour is the last entry in the colour map.