### PR TITLE
feat: new transport loss hotspot maps

### DIFF
--- a/etl/hotspot_layers.csv
+++ b/etl/hotspot_layers.csv
@@ -1,9 +1,11 @@
-hazard,path,rp,rcp,epoch,confidence,variable,unit,key
-hotspots,hotspots/power/demand_affected.tiff,100,baseline,2010,None,demand affected,MWh,powerDemandAffected__rp_100__rcp_baseline__epoch_2010__conf_None
-hotspots,hotspots/power/exposure_value.tiff,100,baseline,2010,None,exposure value,$,powerExposureValue__rp_100__rcp_baseline__epoch_2010__conf_None
-hotspots,hotspots/power/loss_gdp.tiff,100,baseline,2010,None,loss GDP,$,powerLossGdp__rp_100__rcp_baseline__epoch_2010__conf_None
-hotspots,hotspots/power/population_affected.tiff,100,baseline,2010,None,population affected,,powerPopulationAffected__rp_100__rcp_baseline__epoch_2010__conf_None
-hotspots,hotspots/exposure_value_JMD/energy.tiff,100,baseline,2010,None,exposure value,$,powerExposureValue__rp_100__rcp_baseline__epoch_2010__conf_None
-hotspots,hotspots/exposure_value_JMD/transport.tiff,100,baseline,2010,None,exposure value,$,transportExposureValue__rp_100__rcp_baseline__epoch_2010__conf_None
-hotspots,hotspots/exposure_value_JMD/water.tiff,100,baseline,2010,None,exposure value,$,waterExposureValue__rp_100__rcp_baseline__epoch_2010__conf_None
-hotspots,hotspots/exposure_value_JMD/all_sectors.tiff,100,baseline,2010,None,exposure value,$,allExposureValue__rp_100__rcp_baseline__epoch_2010__conf_None
+sector,path,rp,rcp,epoch,confidence,variable,unit,key
+power,hotspots/power/demand_affected.tiff,100,baseline,2010,None,demand affected,MWh,powerDemandAffected__rp_100__rcp_baseline__epoch_2010__conf_None
+power,hotspots/power/exposure_value.tiff,100,baseline,2010,None,exposure value,$,powerExposureValue__rp_100__rcp_baseline__epoch_2010__conf_None
+power,hotspots/power/loss_gdp.tiff,100,baseline,2010,None,loss GDP,$,powerLossGdp__rp_100__rcp_baseline__epoch_2010__conf_None
+power,hotspots/power/population_affected.tiff,100,baseline,2010,None,population affected,,powerPopulationAffected__rp_100__rcp_baseline__epoch_2010__conf_None
+power,hotspots/exposure_value_JMD/energy.tiff,100,baseline,2010,None,exposure value,$,powerExposureValue__rp_100__rcp_baseline__epoch_2010__conf_None
+transport,hotspots/exposure_value_JMD/transport.tiff,100,baseline,2010,None,exposure value,$,transportExposureValue__rp_100__rcp_baseline__epoch_2010__conf_None
+water,hotspots/exposure_value_JMD/water.tiff,100,baseline,2010,None,exposure value,$,waterExposureValue__rp_100__rcp_baseline__epoch_2010__conf_None
+all,hotspots/exposure_value_JMD/all_sectors.tiff,100,baseline,2010,None,exposure value,$,allExposureValue__rp_100__rcp_baseline__epoch_2010__conf_None
+transport,hotspots/transport_economic_loss_JMD_per_day/isolation_loss_smoothed.tiff,100,baseline,2010,None,loss GDP (isolation),$/day,transportLossGdpIsolation__rp_100__rcp_baseline__epoch_2010__conf_None
+transport,hotspots/transport_economic_loss_JMD_per_day/rerouting_loss_smoothed.tiff,100,baseline,2010,None,loss GDP (rerouting),$/day,transportLossGdpRerouting__rp_100__rcp_baseline__epoch_2010__conf_None

--- a/frontend/src/data-layers/risks/color-maps.ts
+++ b/frontend/src/data-layers/risks/color-maps.ts
@@ -12,6 +12,11 @@ export const lossGdp = {
   scheme: 'blues',
   range: [0, 5e6],
 };
+export const lossGdpIsolation = lossGdp;
+export const lossGdpRerouting = {
+  scheme: 'blues',
+  range: [0, 2.5e5],
+};
 /**
  * Colour scheme and range for population values.
  */

--- a/frontend/src/data-layers/risks/domains.ts
+++ b/frontend/src/data-layers/risks/domains.ts
@@ -12,7 +12,7 @@ export const sectorRiskTypes = {
   all: ['exposureValue'],
   power: ['demandAffected', 'exposureValue', 'populationAffected', 'lossGdp'],
   water: ['exposureValue'],
-  transport: ['exposureValue'],
+  transport: ['exposureValue', 'lossGdpIsolation', 'lossGdpRerouting'],
 };
 
 /*

--- a/frontend/src/data-layers/risks/metadata.ts
+++ b/frontend/src/data-layers/risks/metadata.ts
@@ -19,6 +19,16 @@ export const RISKS_METADATA = {
     dataUnit: '',
     format: 'financial',
   },
+  lossGdpIsolation: {
+    label: 'Loss GDP (isolation)',
+    dataUnit: '',
+    format: 'financial',
+  },
+  lossGdpRerouting: {
+    label: 'Loss GDP (rerouting)',
+    dataUnit: '',
+    format: 'financial',
+  },
 };
 
 export const RISKS = Object.keys(RISKS_METADATA);

--- a/frontend/src/data-layers/risks/styles.ts
+++ b/frontend/src/data-layers/risks/styles.ts
@@ -17,4 +17,12 @@ export const RISK_STYLES = makeConfig([
     id: 'lossGdp',
     label: 'Loss GDP',
   },
+  {
+    id: 'lossGdpIsolation',
+    label: 'Loss GDP (isolation)',
+  },
+  {
+    id: 'lossGdpRerouting',
+    label: 'Loss GDP (rerouting)',
+  },
 ]);


### PR DESCRIPTION
- new raster layers for the ETL pipeline
- new risk types for `data-layers/risks`.
- update `RisksControl` to hide layers if they aren't available for a sector.