### PR TITLE
fix(a11y): fieldsets for ParamChecklist

### DIFF
--- a/frontend/src/lib/controls/params/ParamChecklist.tsx
+++ b/frontend/src/lib/controls/params/ParamChecklist.tsx
@@ -29,9 +29,9 @@ export const ParamChecklist = <K extends string = string>({
 
   return (
     <FormGroup>
-      <Box component="fieldset">
+      <Box component="fieldset" sx={{ border: 'none' }}>
+        <FormLabel component="legend">{title}</FormLabel>
         <Stack direction="row" alignItems="center" justifyContent="space-between">
-          <FormLabel component="legend">{title}</FormLabel>
           {showAllNone && (
             <Box>
               <Button disabled={isAll} onClick={() => onChecklistState(fromKeys(keys, true))}>


### PR DESCRIPTION
- `legend` must be the first child of its `fieldset`.
- remove border styling from fieldsets.