### PR TITLE
feat(frontend): allow financial amounts to be rates

### DIFF
--- a/frontend/src/data-layers/risks/metadata.ts
+++ b/frontend/src/data-layers/risks/metadata.ts
@@ -6,7 +6,7 @@ export const RISKS_METADATA = {
   },
   exposureValue: {
     label: 'Exposure value',
-    dataUnit: '',
+    dataUnit: 'JMD',
     format: 'financial',
   },
   populationAffected: {
@@ -16,17 +16,17 @@ export const RISKS_METADATA = {
   },
   lossGdp: {
     label: 'Loss GDP',
-    dataUnit: '',
+    dataUnit: 'JMD/day',
     format: 'financial',
   },
   lossGdpIsolation: {
     label: 'Loss GDP (isolation)',
-    dataUnit: '',
+    dataUnit: 'JMD/day',
     format: 'financial',
   },
   lossGdpRerouting: {
     label: 'Loss GDP (rerouting)',
-    dataUnit: '',
+    dataUnit: 'JMD/day',
     format: 'financial',
   },
 };

--- a/frontend/src/lib/helpers.ts
+++ b/frontend/src/lib/helpers.ts
@@ -24,12 +24,12 @@ export function numFormat(n: number, maximumSignificantDigits: number = 3) {
   return n == null ? `-` : n.toLocaleString(undefined, { maximumSignificantDigits });
 }
 
-export function numFormatMoney(value: number) {
+export function numFormatMoney(value: number, currency: string = 'JMD') {
   return value.toLocaleString(undefined, {
     maximumSignificantDigits: 3,
     maximumFractionDigits: 2,
     style: 'currency',
-    currency: 'JMD',
+    currency,
     currencyDisplay: 'narrowSymbol',
   });
 }

--- a/frontend/src/lib/map/legend/RasterLegend.tsx
+++ b/frontend/src/lib/map/legend/RasterLegend.tsx
@@ -14,7 +14,13 @@ export interface RasterColorMapValues {
 
 const formatter = {
   hazard: (value, dataUnit) => `${value.toLocaleString()} ${dataUnit}`,
-  financial: numFormatMoney,
+  financial: (value, dataUnit) => {
+    const [currency, period] = dataUnit.split('/');
+    if (period) {
+      return `${numFormatMoney(value, currency)}/${period}`;
+    }
+    return numFormatMoney(value, dataUnit);
+  },
   integer: (value) =>
     value.toLocaleString(undefined, {
       maximumSignificantDigits: 3,

--- a/frontend/src/lib/map/tooltip/content/RasterHoverDescription.tsx
+++ b/frontend/src/lib/map/tooltip/content/RasterHoverDescription.tsx
@@ -18,7 +18,13 @@ function useRasterColorMapLookup(colorMapValues) {
 
 const formatter = {
   hazard: (value, dataUnit) => value.toFixed(1) + dataUnit,
-  financial: numFormatMoney,
+  financial: (value, dataUnit) => {
+    const [currency, period] = dataUnit.split('/');
+    if (period) {
+      return `${numFormatMoney(value, currency)}/${period}`;
+    }
+    return numFormatMoney(value, dataUnit);
+  },
   integer: (value) =>
     value.toLocaleString(undefined, {
       maximumSignificantDigits: 3,


### PR DESCRIPTION
Allow financial quantities to be displayed as rates (eg. `JMD/day`) in the raster maps.