### PR TITLE
chore(frontend): 0.4.29

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irv-jamaica",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irv-jamaica",
-      "version": "0.4.28",
+      "version": "0.4.29",
       "dependencies": {
         "@deck.gl/extensions": "^9.1.4",
         "@emotion/react": "^11.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "irv-jamaica",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
- feat: new transport loss hotspot maps.
- feat: add `JMD/day` to supported financial units.
- refactor: tweaks and fixes for hotspot map controls.
- fix(a11y): group controls are now wrapped in fieldsets with legends.
- build(deps): upgrade to Storybook 9.
- build(deps): upgrade to the latest OpenAPI client.