### PR TITLE
refactor(frontend): add numFormatFinancial for loss amounts

### DIFF
--- a/frontend/src/lib/helpers.ts
+++ b/frontend/src/lib/helpers.ts
@@ -34,6 +34,14 @@ export function numFormatMoney(value: number, currency: string = 'JMD') {
   });
 }
 
+export function numFormatFinancial(value: number, dataUnit: string = 'JMD') {
+  const [currency, period] = dataUnit.split('/');
+  if (period) {
+    return `${numFormatMoney(value, currency)}/${period}`;
+  }
+  return numFormatMoney(value, currency);
+}
+
 export function numRangeFormat(n1: number, n2: number) {
   if (n1 == null || n2 == null) return null;
 

--- a/frontend/src/lib/map/legend/RasterLegend.tsx
+++ b/frontend/src/lib/map/legend/RasterLegend.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 
-import { numFormatMoney } from 'lib/helpers';
+import { numFormatFinancial } from 'lib/helpers';
 import { GradientLegend } from './GradientLegend';
 import { useRasterColorMapValues } from './use-color-map-values';
 export interface ColorValue {
@@ -14,13 +14,7 @@ export interface RasterColorMapValues {
 
 const formatter = {
   hazard: (value, dataUnit) => `${value.toLocaleString()} ${dataUnit}`,
-  financial: (value, dataUnit) => {
-    const [currency, period] = dataUnit.split('/');
-    if (period) {
-      return `${numFormatMoney(value, currency)}/${period}`;
-    }
-    return numFormatMoney(value, dataUnit);
-  },
+  financial: numFormatFinancial,
   integer: (value) =>
     value.toLocaleString(undefined, {
       maximumSignificantDigits: 3,

--- a/frontend/src/lib/map/tooltip/content/RasterHoverDescription.tsx
+++ b/frontend/src/lib/map/tooltip/content/RasterHoverDescription.tsx
@@ -2,7 +2,7 @@ import { Box } from '@mui/material';
 import { FC, useMemo } from 'react';
 
 import { useRasterColorMapValues } from 'lib/map/legend/use-color-map-values';
-import { numFormatMoney } from 'lib/helpers';
+import { numFormatFinancial } from 'lib/helpers';
 
 import { DataItem } from '../detail-components';
 import { ColorBox } from './ColorBox';
@@ -18,13 +18,7 @@ function useRasterColorMapLookup(colorMapValues) {
 
 const formatter = {
   hazard: (value, dataUnit) => value.toFixed(1) + dataUnit,
-  financial: (value, dataUnit) => {
-    const [currency, period] = dataUnit.split('/');
-    if (period) {
-      return `${numFormatMoney(value, currency)}/${period}`;
-    }
-    return numFormatMoney(value, dataUnit);
-  },
+  financial: numFormatFinancial,
   integer: (value) =>
     value.toLocaleString(undefined, {
       maximumSignificantDigits: 3,


### PR DESCRIPTION
Add `numFormatFinancial`, which supports financial rates (eg. `JMD/day`.)