### PR TITLE
fix: isolate storybook test config

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -31,15 +31,7 @@ try {
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-    react(),
-    viteTsconfigPaths(),
-    url(),
-    svgr(),
-    // The plugin will run tests for the stories defined in your Storybook config
-    // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
-    storybookTest({ configDir: path.join(dirname, '.storybook') }),
-  ],
+  plugins: [react(), viteTsconfigPaths(), url(), svgr()],
   build: {
     outDir: 'build',
   },
@@ -48,13 +40,25 @@ export default defineConfig({
     proxy: devProxy,
   },
   test: {
-    name: 'storybook',
-    browser: {
-      enabled: true,
-      headless: true,
-      provider: 'playwright',
-      instances: [{ browser: 'chromium' }],
-    },
-    setupFiles: ['.storybook/vitest.setup.ts'],
+    projects: [
+      {
+        extends: true,
+        plugins: [
+          // The plugin will run tests for the stories defined in your Storybook config
+          // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
+          storybookTest({ configDir: path.join(dirname, '.storybook') }),
+        ],
+        test: {
+          name: 'storybook',
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: 'playwright',
+            instances: [{ browser: 'chromium' }],
+          },
+          setupFiles: ['.storybook/vitest.setup.ts'],
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
Isolate the Vite config for tests, so that it doesn't interfere with the build for the production storybook.