### PR TITLE
Fix scope of API request for sorted features to asset type

### DIFF
--- a/frontend/src/data-layers/networks/state/layer.ts
+++ b/frontend/src/data-layers/networks/state/layer.ts
@@ -91,7 +91,7 @@ export const adaptationLayerSpecState = selector<LayerSpec>({
     return {
       sector,
       subsector,
-      assetType: asset_type,
+      asset_type: asset_type,
     };
   },
 });

--- a/frontend/src/lib/asset-list/use-sorted-features.ts
+++ b/frontend/src/lib/asset-list/use-sorted-features.ts
@@ -76,7 +76,7 @@ export interface LayerSpec {
   layer?: string;
   sector?: string;
   subsector?: string;
-  assetType?: string;
+  asset_type?: string;
 }
 export type ListFeature = Omit<FeatureListItemOutFloat, 'bbox_wkt'> & {
   bbox: BoundingBox;


### PR DESCRIPTION
Bug showed up on Adaptation tab: 
- select Transport > Air > Terminal
- expect right-hand sidebar table to list only terminals (one row)
- actual response lists all air assets (~9 rows including runways)

`GET` request to `/api/features/sorted-by/adaptation` includes `assetType=terminal`, backend expects `asset_type=terminal`, as defined in `LayerSpec`:

https://github.com/nismod/irv-jamaica/blob/502464c1cbff7a51acddab2cfacc5a48ed0833e8/backend/backend/app/schemas.py#L157