### PR TITLE
Build raster tileserver with terracotta 0.9.1 / python 3.12

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -67,7 +67,7 @@ services:
       - "traefik.http.services.vector-tileserver.loadbalancer.server.port=8080"
 
   raster-tileserver:
-    image: ghcr.io/nismod/jsrat-raster-tileserver:0.1
+    image: ghcr.io/nismod/jsrat-raster-tileserver:0.2
     build: ./tileserver/raster
     volumes:
       - ./tileserver/raster/data:/data

--- a/tileserver/raster/Dockerfile
+++ b/tileserver/raster/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.10
+FROM python:3.12
 
-RUN apt-get update && apt-get install -y libgdal-dev
+RUN apt-get update && apt-get upgrade -y && apt-get install -y libgdal-dev
 WORKDIR /code
 COPY requirements.txt requirements.txt
 RUN python -m pip install --upgrade pip setuptools wheel

--- a/tileserver/raster/requirements.txt
+++ b/tileserver/raster/requirements.txt
@@ -1,4 +1,2 @@
-cython~=3.0.12
-terracotta~=0.8
+terracotta==0.9.1
 gunicorn
-numpy>=1.15,!=1.17.0,<1.24


### PR DESCRIPTION
- pin terracotta precisely (database can change and will error between minor versions)
- let terracotta's requirements define numpy, cython versions
- bump python base container to 3.12, run apt upgrade in build step