### PR TITLE
State inputs before preparing features from database for vector tiles

### DIFF
--- a/etl/Snakefile
+++ b/etl/Snakefile
@@ -116,6 +116,9 @@ rule adaptation_to_db:
 rule db_to_geojsonseq:
     """Load from database to GeoJSONSeq
     """
+    input:
+        "logs/network/{layer}.txt",
+        "logs/damages_exp/{layer}.txt",
     output:
         "vector/{layer}.geojsonl",
     script:


### PR DESCRIPTION
Make `features` and `damages_expected` explicit prerequisites before dumping to GeoJSONSeq - the vector tiles should include selected feature properties and expected damages.

This should fix the order of operations in ETL, with the intention that damages then display correctly on the map in the "Risk" tab for roads.