### PR TITLE
Revert damage prerequisite for vector tiles 

### DIFF
--- a/etl/Snakefile
+++ b/etl/Snakefile
@@ -116,9 +116,6 @@ rule adaptation_to_db:
 rule db_to_geojsonseq:
     """Load from database to GeoJSONSeq
     """
-    input:
-        "logs/network/{layer}.txt",
-        "logs/damages_exp/{layer}.txt",
     output:
         "vector/{layer}.geojsonl",
     script:


### PR DESCRIPTION
Revert "Link prerequisites of preparing features from database for tiles"

This reverts commit f8751ad0fea1063116c58abadbf95b397d3f76ed.