### PR TITLE
bug: failed coastal_adaptation_protected_assets_to_db rule due to wildcard constraint

### DIFF
--- a/etl/Snakefile
+++ b/etl/Snakefile
@@ -132,11 +132,11 @@ rule coastal_adaptation_to_db:
 rule coastal_adaptation_protected_assets_to_db:
     input:
         avoided_risk=f"{config['analysis_data_dir']}/results/adaptation_benefits_costs_bcr/coastal_{{layer}}_adaptation_costs_avoided_EAD_EAEL.csv",
-        protector_dict = f"{config['analysis_data_dir']}/results/coastal_protection_assets/network_protection_mappings/{{layer}}_coastal_filtered.parquet",
+        protector_dict=f"{config['analysis_data_dir']}/results/coastal_protection_assets/network_protection_mappings/{{layer}}_coastal_filtered.parquet",
         uid=f"{config['analysis_data_dir']}/processed_data/networks_uids/id_lookups/{{layer}}_ids.parquet",
         p_uid=f"{config['analysis_data_dir']}/processed_data/networks_uids/id_lookups/coastal_protection_feature_areas_ids.parquet",
     wildcard_constraints:
-        layer=r"^((?!coastal_protection_feature).)$",  # Everything except the defence features themselves
+        layer="(?!coastal_protection_feature_areas$).*"
     output:
         "logs/adaptation_coastal/{layer}.txt",
     script:


### PR DESCRIPTION
#### Problem 
The wildcard constraint regex for the **coastal_adaptation_protected_assets_to_db** rule in the etl [Snakefile](https://github.com/nismod/irv-jamaica/blob/0b2626e7c0b6afcbafc281117c1eecb871dccb32/etl/Snakefile#L139) appeared to be incorrectly trying to match single characters instead of the full layer names, causing the rule to throw a missing input files error.

 #### Proposed Solution
 Updated to `"(?!coastal_protection_feature_areas$).*"` to properly exclude the **coastal_protection_feature_areas** layer while allowing all the other layers, as originally intended.