### PR TITLE
bugfix: Failed execution of networks_to_db snakemake rule, missing coastal protection network layer

### DIFF
--- a/etl/scripts/networks_to_db.py
+++ b/etl/scripts/networks_to_db.py
@@ -73,7 +73,13 @@ def clean_props(props, rename):
     return clean
 
 
-def get_network_layer(layer_name, network_layers):
+def get_network_layer(layer_name, network_layers, network_layers_areal_protection):
+    if not network_layers_areal_protection.empty:
+        if set(network_layers.columns) == set(network_layers_areal_protection):
+            network_layers = pandas.concat([network_layers, network_layers_areal_protection], ignore_index=True)
+        else:
+            raise ValueError("network_layers_areal_protection could not be appended to network_layers. DataFrames have different fields")
+    breakpoint()
     try:
         return network_layers[network_layers.ref == layer_name].iloc[0]
     except IndexError as e:
@@ -111,13 +117,14 @@ if __name__ == "__main__":
         analysis_data_dir = snakemake.config["analysis_data_dir"]
 
         network_layers = pandas.read_csv(snakemake.config["network_layers"])
+        network_layers_areal_protection = pandas.read_csv(snakemake.config["network_layers_areal_protection"])
         network_tilelayers = pandas.read_csv(snakemake.config["network_tilelayers"])
 
     except NameError:
         print("Expected to run from snakemake")
         exit()
 
-    layer = get_network_layer(layer, network_layers)
+    layer = get_network_layer(layer, network_layers,network_layers_areal_protection)
     tilelayers = list(get_tilelayers_by_network_source(layer, network_tilelayers))
 
     db: Session

--- a/etl/scripts/networks_to_db.py
+++ b/etl/scripts/networks_to_db.py
@@ -75,7 +75,7 @@ def clean_props(props, rename):
 
 def get_network_layer(layer_name, network_layers, network_layers_areal_protection):
     if not network_layers_areal_protection.empty:
-        if set(network_layers.columns) == set(network_layers_areal_protection):
+        if set(network_layers.columns) == set(network_layers_areal_protection.columns):
             network_layers = pandas.concat([network_layers, network_layers_areal_protection], ignore_index=True)
         else:
             raise ValueError("network_layers_areal_protection could not be appended to network_layers. DataFrames have different fields")

--- a/etl/scripts/networks_to_db.py
+++ b/etl/scripts/networks_to_db.py
@@ -79,7 +79,6 @@ def get_network_layer(layer_name, network_layers, network_layers_areal_protectio
             network_layers = pandas.concat([network_layers, network_layers_areal_protection], ignore_index=True)
         else:
             raise ValueError("network_layers_areal_protection could not be appended to network_layers. DataFrames have different fields")
-    breakpoint()
     try:
         return network_layers[network_layers.ref == layer_name].iloc[0]
     except IndexError as e:


### PR DESCRIPTION
#### Problem

When attempting to run the **networks_to_db** snakmake rule for layer wildcard 'coastal_protection_areas', the rule fails and raises the error "Could not find coastal_protection_areas in network layers." This error is being raised by the **networks_to_db.py** script when it attempts to execute the [get_network_layer function](https://github.com/nismod/irv-jamaica/blob/3e1741f7fb75ac41f7e2797bf780bd8d16c06059/etl/scripts/networks_to_db.py#L76). 

This is likely due to the fact that the coastal_protection_areas row is absent from the network_layers.csv and is only present in the **network_layers_areal_protection.csv**.

#### Proposed Solution

Within the script a new dataframe was initialised for network_layers_areal_protection.csv, 
`network_layers_areal_protection = pandas.read_csv(snakemake.config["network_layers_areal_protection"])` and was passed as another argument to the get_network_layer function.

The below logic was also added to the function to check if the new dataframe is empty, if not it appends its contents to the network layers dataframe. I also included an error check to ensure both dataframes have the same fields.

```
if not network_layers_areal_protection.empty:
        if set(network_layers.columns) == set(network_layers_areal_protection):
            network_layers = pandas.concat([network_layers, network_layers_areal_protection], ignore_index=True)
        else:
            raise ValueError("network_layers_areal_protection could not be appended to network_layers. DataFrames have different fields")
```