### PR TITLE
fix: round lat/lon to 4 decimal places

### DIFF
--- a/frontend/src/details/pixel-data/PixelData.stories.tsx
+++ b/frontend/src/details/pixel-data/PixelData.stories.tsx
@@ -30,7 +30,12 @@ export const Default: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get('/pixel/18.000/-78.000', () => {
+        http.get('/pixel/:lat/:lon', ({ params }) => {
+          const { lat, lon } = params;
+          console.log(lat, lon)
+          if (lat !== '18.0000' || lon !== '-78.0000') {
+            return HttpResponse.json({ error: 'Not found' }, { status: 404 });
+          }
           return HttpResponse.json(mockPixelData);
         }),
       ],

--- a/frontend/src/lib/state/pixel-driller.ts
+++ b/frontend/src/lib/state/pixel-driller.ts
@@ -67,11 +67,13 @@ const pixelDrillerQuery: Atom<Promise<PixelData | null>> = atom(async (get) => {
     return Promise.resolve(null);
   }
   const { lat, lon } = pixelSelection;
-  const key = `${lat.toFixed(3)}-${lon.toFixed(3)}`;
+  const roundedLat = lat.toFixed(4);
+  const roundedLon = lon.toFixed(4);
+  const key = `${roundedLat}-${roundedLon}`;
   if (dataCache.has(key)) {
     return dataCache.get(key) ?? null;
   }
-  const response = await fetch(`/pixel/${lon.toFixed(3)}/${lat.toFixed(3)}`);
+  const response = await fetch(`/pixel/${roundedLon}/${roundedLat}`);
   const data: PixelData = await response.json();
   dataCache.set(key, data);
   return data;


### PR DESCRIPTION
Round lat/lon to 4 decimal places in the pixel-driller API client.
- closes #445.