### PR TITLE
fix: don't expand accordions that have no data

### DIFF
--- a/frontend/src/details/pixel-data/hazard-accordion.tsx
+++ b/frontend/src/details/pixel-data/hazard-accordion.tsx
@@ -42,7 +42,7 @@ export function HazardAccordion({ id, title, status = 'green', children }: Hazar
   );
 
   return (
-    <Accordion expanded={expanded} onChange={handleChange} disabled={disabled}>
+    <Accordion expanded={expanded && !disabled} onChange={handleChange} disabled={disabled}>
       <AccordionSummary
         expandIcon={<ExpandMoreIcon />}
         sx={{


### PR DESCRIPTION
If a hazard accordion has no data, it should be disabled and not expanded.
- closes #443.