### PR TITLE
feat: custom chart colours and shapes

### DIFF
--- a/frontend/src/details/features/damages/ExpectedDamageChart.tsx
+++ b/frontend/src/details/features/damages/ExpectedDamageChart.tsx
@@ -55,11 +55,21 @@ const makeSpec = (
       type: 'ordinal',
       scale: {
         domain: ['baseline', '2.6', '4.5', '8.5'],
+        range: ['#737373', '#e77600', '#aec750', '#1f77b4'],
       },
       title: 'RCP',
       legend: {
         orient: 'bottom',
         direction: 'horizontal',
+      },
+    },
+    shape: {
+      field: 'rcp',
+      type: 'ordinal',
+      legend: null,
+      scale: {
+        domain: ['baseline', '2.6', '4.5', '8.5'],
+        range: ['circle', 'square', 'triangle-up', 'diamond'],
       },
     },
     // the tooltip encoding needs to replicate the field definitions in order to customise their ordering

--- a/frontend/src/details/features/damages/ReturnPeriodDamageChart.tsx
+++ b/frontend/src/details/features/damages/ReturnPeriodDamageChart.tsx
@@ -53,12 +53,21 @@ const makeSpec = (
       scale: {
         domain: ['baseline', '2.6', '4.5', '8.5'],
         // Could do custom colours
-        // range: ["#e7ba52", "#c7c7c7", "#aec7e8", "#1f77b4"]
+        range: ['#737373', '#e77600', '#aec750', '#1f77b4'],
       },
       title: 'RCP',
       legend: {
         orient: 'bottom',
         direction: 'horizontal',
+      },
+    },
+    shape: {
+      field: 'rcp',
+      type: 'ordinal',
+      legend: null,
+      scale: {
+        domain: ['baseline', '2.6', '4.5', '8.5'],
+        range: ['circle', 'square', 'triangle-up', 'diamond'],
       },
     },
     // the tooltip encoding needs to replicate the field definitions in order to customise their ordering


### PR DESCRIPTION
Custom colours and shapes to distinguish between RCP scenarios in the damage charts.
- towards #444.