### PR TITLE
fix: round exported pixel data values

### DIFF
--- a/frontend/src/details/pixel-data/PixelData.tsx
+++ b/frontend/src/details/pixel-data/PixelData.tsx
@@ -8,6 +8,7 @@ import { MobileTabContentWatcher } from 'lib/map/layouts/tab-has-content';
 import {
   pixelDrillerDataHeaders,
   pixelDrillerDataState,
+  pixelDrillerExportRecords,
   pixelSelectionState,
 } from 'lib/state/pixel-driller';
 import Close from '@mui/icons-material/Close';
@@ -17,7 +18,6 @@ import { DownloadDataProvider, useDownloadDataContext } from './download/downloa
 import { buildReadmeFile } from './download/download-generators';
 import { createSpatialPoint } from './download/metadata-common';
 import type { RdlsMetadataPackage } from './download/metadata-types';
-import type { PixelDomain, PixelRecord } from './types';
 import { buildZipFile, downloadBlob } from './download/download-utils';
 import type { DownloadFile } from './download/types';
 
@@ -41,43 +41,12 @@ const datasetFetchers = {
   cyclone: await domainModules.cyclone().then((mod) => mod.getMetadata),
 };
 
-const PIXEL_DOMAINS = new Set<PixelDomain>(['fluvial', 'surface', 'coastal', 'cyclone']);
-
-const mapSelectedDataToRecords = (
-  selectedData: NonNullable<ReturnType<typeof useAtomValue<typeof pixelDrillerDataState>>>,
-): PixelRecord[] => {
-  return selectedData.key
-    .map((_, i): PixelRecord | null => {
-      const domain = selectedData.hazard[i];
-      if (!PIXEL_DOMAINS.has(domain as PixelDomain)) {
-        return null;
-      }
-
-      return {
-        value: selectedData.band_data[i] ?? null,
-        layer: {
-          domain: domain as PixelDomain,
-          id: selectedData.key[i] ?? `${domain}-${i}`,
-          keys: {
-            key: selectedData.key[i],
-            rp: selectedData.rp[i] != null ? selectedData.rp[i] : undefined,
-            rcp: selectedData.rcp[i],
-            epoch: selectedData.epoch[i] != null ? selectedData.epoch[i] : undefined,
-            confidence: selectedData.confidence[i] != null ? selectedData.confidence[i] : undefined,
-            unit: selectedData.unit[i],
-            variable: selectedData.variable[i],
-          },
-        },
-      };
-    })
-    .filter((record): record is PixelRecord => record !== null);
-};
-
 /**
  * Display detailed information about a selected pixel (lat/lon point.)
  */
 const PixelDataInner = () => {
   const selectedData = useAtomValue(pixelDrillerDataState);
+  const exportRecords = useAtomValue(pixelDrillerExportRecords);
   const headers = useAtomValue(pixelDrillerDataHeaders);
   const [pixelSelection, setPixelSelection] = useAtom(pixelSelectionState);
   const [downloading, setDownloading] = useState(false);
@@ -101,8 +70,6 @@ const PixelDataInner = () => {
   const makeDownloadZipFile = async () => {
     if (!selectedData || lat == null || lon == null) return;
 
-    const allRecords = mapSelectedDataToRecords(selectedData);
-
     setDownloading(true);
     try {
       const exportConfigs = getAllExportConfigs();
@@ -112,7 +79,7 @@ const PixelDataInner = () => {
         exportConfigs.entries(),
       ).map(async ([key, { exportFunction }]) => {
         try {
-          return await exportFunction(allRecords);
+          return await exportFunction(exportRecords);
         } catch (err) {
           console.error(`Error exporting data for ${key}:`, err);
           return [] as DownloadFile[];

--- a/frontend/src/details/pixel-data/domains/coastal.tsx
+++ b/frontend/src/details/pixel-data/domains/coastal.tsx
@@ -1,10 +1,13 @@
 import { useAtomValue } from 'jotai';
 
-import { pixelDrillerDataRecords } from 'lib/state/pixel-driller';
+import {
+  type PixelRecord,
+  type PixelRecordKeys,
+  pixelDrillerDataRecords,
+} from 'lib/state/pixel-driller';
 
 import { HazardAccordion } from '../hazard-accordion';
 import { EpochReturnPeriodChart } from '../epoch-return-period-chart';
-import type { PixelRecord, PixelRecordKeys } from '../types';
 import { buildDomainExportFile } from '../download/download-generators';
 import {
   ExportConfig,

--- a/frontend/src/details/pixel-data/domains/cyclone.tsx
+++ b/frontend/src/details/pixel-data/domains/cyclone.tsx
@@ -1,6 +1,10 @@
 import { useAtomValue } from 'jotai';
 
-import { pixelDrillerDataRecords } from 'lib/state/pixel-driller';
+import {
+  type PixelRecord,
+  type PixelRecordKeys,
+  pixelDrillerDataRecords,
+} from 'lib/state/pixel-driller';
 
 import { HazardAccordion } from '../hazard-accordion';
 import { EpochReturnPeriodChart } from '../epoch-return-period-chart';
@@ -18,7 +22,6 @@ import {
   COMMON_CREATOR,
 } from '../download/metadata-common';
 import type { DatapackageTableSchemaField, RdlsDataset } from '../download/metadata-types';
-import type { PixelRecordKeys, PixelRecord } from '../types';
 import type { RagStatus } from '../rag/rag-types';
 import { calculateRagFromReturnPeriodValuesOneThreshold } from '../rag/rag-calculation';
 

--- a/frontend/src/details/pixel-data/domains/fluvial.tsx
+++ b/frontend/src/details/pixel-data/domains/fluvial.tsx
@@ -1,10 +1,13 @@
 import { useAtomValue } from 'jotai';
 
-import { pixelDrillerDataRecords } from 'lib/state/pixel-driller';
+import {
+  type PixelRecord,
+  type PixelRecordKeys,
+  pixelDrillerDataRecords,
+} from 'lib/state/pixel-driller';
 
 import { HazardAccordion } from '../hazard-accordion';
 import { EpochReturnPeriodChart } from '../epoch-return-period-chart';
-import type { PixelRecord, PixelRecordKeys } from '../types';
 import { buildDomainExportFile } from '../download/download-generators';
 import {
   ExportConfig,

--- a/frontend/src/details/pixel-data/domains/surface.tsx
+++ b/frontend/src/details/pixel-data/domains/surface.tsx
@@ -1,6 +1,10 @@
 import { useAtomValue } from 'jotai';
 
-import { pixelDrillerDataRecords } from 'lib/state/pixel-driller';
+import {
+  type PixelRecord,
+  type PixelRecordKeys,
+  pixelDrillerDataRecords
+} from 'lib/state/pixel-driller';
 
 import { HazardAccordion } from '../hazard-accordion';
 import { EpochReturnPeriodChart } from '../epoch-return-period-chart';
@@ -18,7 +22,6 @@ import {
   COMMON_CREATOR,
 } from '../download/metadata-common';
 import type { DatapackageTableSchemaField, RdlsDataset } from '../download/metadata-types';
-import type { PixelRecordKeys, PixelRecord } from '../types';
 import type { RagStatus } from '../rag/rag-types';
 import { calculateRagFromReturnPeriodValuesOneThreshold } from '../rag/rag-calculation';
 

--- a/frontend/src/details/pixel-data/download/download-context.tsx
+++ b/frontend/src/details/pixel-data/download/download-context.tsx
@@ -9,9 +9,9 @@ import {
   useState,
 } from 'react';
 
-import type { DownloadFile } from './types';
+import type { PixelRecord } from 'lib/state/pixel-driller';
 
-import type { PixelRecord } from '../types';
+import type { DownloadFile } from './types';
 import type { RdlsDataset, RdlsLocation } from './metadata-types';
 
 /**

--- a/frontend/src/details/pixel-data/download/download-generators.ts
+++ b/frontend/src/details/pixel-data/download/download-generators.ts
@@ -1,7 +1,8 @@
 import { d3 } from 'lib/d3';
 
+import type { PixelRecord, PixelRecordKeys } from 'lib/state/pixel-driller';
+
 import type { DownloadFile } from './types';
-import type { PixelRecord, PixelRecordKeys } from '../types';
 import { ExportConfig } from './download-context';
 import type { DatapackageTableSchemaField } from './metadata-types';
 import readmeTemplate from './README.md.txt?raw';

--- a/frontend/src/details/pixel-data/types.ts
+++ b/frontend/src/details/pixel-data/types.ts
@@ -1,17 +1,4 @@
-export type PixelDomain = 'fluvial' | 'surface' | 'coastal' | 'cyclone';
-
-// Base type for pixel record keys - all keys are optional strings
-export type PixelRecordKeys = Record<string, string | number | undefined>;
-
-// Generic pixel record that accepts a specific keys type
-export interface PixelRecord<TKeys extends PixelRecordKeys = PixelRecordKeys> {
-  value: number | null;
-  layer: {
-    domain: PixelDomain;
-    keys: TKeys;
-    id: string;
-  };
-}
+import type { PixelDomain, PixelRecord, PixelRecordKeys } from 'lib/state/pixel-driller';
 
 export interface PixelResponse {
   point: {

--- a/frontend/src/lib/state/pixel-driller.ts
+++ b/frontend/src/lib/state/pixel-driller.ts
@@ -3,6 +3,21 @@ import { atomFamily } from 'jotai-family';
 import { unwrap } from 'jotai/utils';
 import { atomWithStoredJson } from './map-view/map-url';
 
+export type PixelDomain = 'fluvial' | 'surface' | 'coastal' | 'cyclone';
+
+// Base type for pixel record keys - all keys are optional strings
+export type PixelRecordKeys = Record<string, string | number | undefined>;
+
+// Generic pixel record that accepts a specific keys type
+export interface PixelRecord<TKeys extends PixelRecordKeys = PixelRecordKeys> {
+  value: number | null;
+  layer: {
+    domain: PixelDomain;
+    keys: TKeys;
+    id: string;
+  };
+}
+
 type PixelData = {
   band_data: number[];
   confidence: number[];
@@ -279,3 +294,54 @@ const pixelDrillerDataRecordsFamily = atomFamily(
     }),
   (a, b) => a.pixel_layer === b.pixel_layer && a._serialized === b._serialized,
 );
+
+const PIXEL_DOMAINS = new Set<PixelDomain>(['fluvial', 'surface', 'coastal', 'cyclone']);
+
+const pixelDrillerRecords = atom((get) => {
+  const selectedData = get(pixelDrillerDataState);
+  if (!selectedData) {
+    return [];
+  }
+  return selectedData.key
+    .map((_, i): PixelRecord | null => {
+      const domain = selectedData.hazard[i];
+      if (!PIXEL_DOMAINS.has(domain as PixelDomain)) {
+        return null;
+      }
+
+      return {
+        value: selectedData.band_data[i] ?? null,
+        layer: {
+          domain: domain as PixelDomain,
+          id: selectedData.key[i] ?? `${domain}-${i}`,
+          keys: {
+            key: selectedData.key[i],
+            rp: selectedData.rp[i] != null ? selectedData.rp[i] : undefined,
+            rcp: selectedData.rcp[i],
+            epoch: selectedData.epoch[i] != null ? selectedData.epoch[i] : undefined,
+            confidence: selectedData.confidence[i] != null ? selectedData.confidence[i] : undefined,
+            unit: selectedData.unit[i],
+            variable: selectedData.variable[i],
+          },
+        },
+      };
+    })
+    .filter((record): record is PixelRecord => record !== null);
+});
+
+function fixedPrecisionNumber(n: number | null, precision: number): number | null {
+  if (Number.isFinite(n)) {
+    return Number(n.toPrecision(precision));
+  }
+  return n;
+}
+
+export const pixelDrillerExportRecords = atom<PixelRecord[]>((get) => {
+  const records = get(pixelDrillerRecords);
+  return records.map((record) => ({
+    value: fixedPrecisionNumber(record.value, 3),
+    layer: {
+      ...record.layer,
+    },
+  }));
+});


### PR DESCRIPTION
- refactor pixel data export to use a pre-computed atom for exports.
- round exported values to 3 significant figures.
- towards #444. 